### PR TITLE
updates of all Tutorials.

### DIFF
--- a/docs/Tutorial_NPCMoveCampsSoD.html
+++ b/docs/Tutorial_NPCMoveCampsSoD.html
@@ -115,13 +115,13 @@
       <div id="toc">
         <h2><a name="toc">Contents</a></h2>
         <ol class="toc">
-          <li><a href="#toc_1">Transition into SoD: change Biff's OVERRIDE script to the SoD one for a continuous BG:EE-SoD game</a></li>
+          <li><a href="#toc_1">General throughts to transition into SoD "Korlasz' Crypt"</a></li>
           <li><a href="#toc_2b">Add Biff to Corwin's list about companions in BG city</a></li>
-          <li><a href="#toc_2">Make Biff leave party after Korlasz's Crypt is cleared</a></li>
+          <li><a href="#toc_2">Make Biff leave party after Korlasz' Crypt is cleared</a></li>
           <li><a href="#toc_3">Moving Biff to his new meeting point in BG city</a></li>
           <li><a href="#toc_4">Make Biff wait outside the Ducal Palace when PC marches against crusade</a></li>
           <li><a href="#toc_5">Move Biff to first camp in Coast Way Crossing (bd1000.are)</a></li>
-          <li><a href="#toc_6">Move Biff to 2nd camp in Troll Claw Woods (bd7100.are)</a></li>
+          <li><a href="#toc_6">Move Biff to 2<sup>nd</sup> camp in Troll Claw Woods (bd7100.are)</a></li>
           <li><a href="#toc_7">Move Biff to the Coalition Camp in bd3000.are</a></li>
           <li><a href="#toc_7b">Move NPC to entrance of the Allied Siege Camp (Crusade battle)</a></li>
           <li><a href="#toc_8">Make Biff return to camp if told so after being kicked out in wilderness area</a></li>
@@ -134,7 +134,7 @@
         </ol>
       </div>
 
-      <p class="info">This tutorial deals with the transition of an NPC from BG:EE to SoD and how to move your NPC from one SoD area to another depending on the campaign's progress if they are not in the group. As an example NPC, Biff the Understudy will be the NPC in this guide!</p>
+      <p class="info">This tutorial deals with the transition of an NPC from BG:EE to SoD, how to spwn them for the first meeting after the main SoD campaign started, and how to move your NPC from one SoD area to another depending on the campaign's progress if they are not in the group. As an example NPC, Biff the Understudy will be the NPC in this guide!</p>
       <p><strong>Some nomenclature:</strong></p>
       <table>
         <col width="180" />
@@ -149,11 +149,16 @@
         </tr>
         <tr>
           <td>xxBiff</td>
-          <td>Biff's script name (death variable)</td>
+          <td>Biff's scriptname (death variable)</td>
         </tr>
         <tr>
           <td>xxBiffs.dlg</td>
           <td>Biff's greeting dialogue in SoD</td>
+        </tr>
+        <tr>
+        <tr>
+          <td>xxBiffJ.dlg</td>
+          <td>Biff's joined dialogue in SoD (note: and also BG1 if he would be available)</td>
         </tr>
         <tr>
           <td>xxBiffs.bcs</td>
@@ -181,67 +186,90 @@
         </tr>
       </table>
 	  
-	  <h2><a name="toc_1">1. Transition into SoD: change Biff's OVERRIDE script to the SoD one for a continuous BG:EE-SoD game</a></h2>
-      <p class="info">This section is only of interest if your NPC was also available in BG:EE. If your NPC is a pure SoD NPC, you can skip this section.</p>
-	  <p>If your NPC was also available in BG:EE, it is good practise to change the OVERRIDE script to a SoD specific one upon the transition into SoD. The advantages are simple: you don't have to take care that events related to BG:EE story or areas do not fire any more. Of course you can also continue using the former OVERRIDE script and make sure by using the according triggers that only SoD related actions will be triggered.</p>	  
-	  <p class="info">Sidenote: if you want to distinguish between BG:EE and SoD, an easy way to detect SoD in a BG:EE+SoD game is by using the unique variable "GlobalGT("bd_plot","global",0)" which is set to "2" at the beginning of the SoD intro cutscene (where the two followers of Korlasz are talking beside the chasm: "Sarevok's dead. Everything's a mess. We should have gotten out of the city days ago.") This might be more useful for dialogues, though (PID, for example), since it's good practice to just use a separate script for SoD. (For EET, you can use "Global("ENDOFBG1","GLOBAL",1)" for the SoD portion of the game, which will be set to "2" in BGII.) And while we are at it: after finishing Korlasz' crypt and the PC being woken up by Imoen in the Ducal Palace, the check variable for SoD would be "GlobalGT("BD_PLOT","GLOBAL",50)" - just in case you want to count the intro dungeon to "BG:EE", content wise.</p>
+	  <h2><a name="toc_1">1. General throughts to transition into SoD "Korlasz' Crypt"</a></h2>
+      <p class="info">This section is only of interest if your NPC was also available in BG:EE. If your NPC is a pure SoD NPC that will wait after the transition into the palace, you can skip this section.</p>
+      <p class="info">Please be aware that my tutorials assume that your mod NPC uses the same joined dialogue in SoD like they use in the BG1 part of the game. If you are using a different joined dialogue for the SoD part, not only compatibility with EndlessBG1's and Transitions' "Korlasz' Crypt is in BG1" content will require special handling, but also examples in my tutorial mod about patching bddialog.2da etc. will need to be adjusted.</p>
 	  <p>After the end of BG:EE, the transition to SoD is done first by the cutscene "bdsodtrn.bcs" (triggered by Sarevok's death in AR0125.bcs) which sets the Global("SOD_fromimport","GLOBAL",1) with which the continuous game will be detected later, resurrects and completely heals all NPCs, and starts the SoD campaign ("MoveToCampaign("SoD")"). After that, the bd0120.bcs does party rearrangements depending on who is present (change Viconia's portrait, remove Imoen from the party, substituting her with Safana in case the party lacks a thief with either open locks or detect traps ability etc.) and calls the cutscene bdintro.bcs, which makes newly spawned replacement NPCs join the party and sets the NPCs override scripts and dialogues to the SoD ones.</p>
-	  <p>So, if your NPC should use SoD specific joined dialogue and OVERRIDE script, we need to patch the <strong>bdintro.bcs</strong> with the following (with Biff being our example NPC):</p>
+	  <p>For compatibility with my EndlessBG1 mod I do not recommend to switch to the SoD script upon transitioning to Korlasz' Dungeon any more. Instead, my NPC mods treat Korlasz' Dungeon as BG1 content, i.e. they use BG1 script and dialogues inside Korlasz' Crypt. In addition, my mod NPCs use the same joined dialogues for BG1 and SoD.</p>
+	  <p>Reason is that the IE engine resets the NPCs' joined dialogues to the entry in the active (p/bd)dialog.2da, and banter files are the active ones in the interdia/bdbanter.2da. With Korlasz' Crypt moved into the BG1 "world" by the mods EndlessBG1 (component 14) or Transitions, this means that all NPCs' banter files will still be the BG1 ones inside the crypt - and all joined dialogue files get reset to the BG1 ones every time the player loads a save. By using the same joined dialogue for your mod NPC in BG1 and SoD, you do not have to worry about the joined dialogue of your NPC being switched. This also means that if you are using a different SoD joined dialogue, you need to make sure it is always active while the group is inside Korlasz' Dungeon, regardless whether it is still BG1 or original SoD. Also, one would have to distinguish between Korlasz' Crypt in SoD and Korlasz' Crypt in BG1 with regard to the originals NPCs' banter dialogues in case your NPC tries to start a banter while being in the crypt. See also here for more info: <a href="https://www.gibberlings3.net/forums/topic/34948-how-to-original-npc-scripts-and-dialogue-in-korlasz-tomb-and-compatibility-with-endlessbg1-and-transitions-community-effort/">[How-To] Original NPC Scripts and Dialogue in Korlasz' Crypt and compatibility with EndlessBG1 and Transitions (Community Effort)</a></p>
+	  <p>This means that I removed the former recommendation to patch the bdintro.bcs with a switch of your mod NPC's OVERRIDE script (and dialogue) to the SoD one but am recommending to treat Korlasz' Dungeon like BG1 content with regard to your NPC's dialogue and script instead. Also, I recommend using one joined dialogue name for SoD and BG1.</p>	  
+	  <p class="info">Note: Switching to your NPC's SoD script (and SoD greetings dialogue) will be done later when they are moved to the first meeting area in SoD as described in later sections of this tutorial. If your NPC is supposed to just stay with the PC like for example my Grey the Dog, switching to SoD OVERRIDE script needs to be done accordingly, either inside the sodtrn.bcs, bd0103.bcs, or even the NPC's own BG1 script upon arriving in bd0103.are. (Just for info: Grey the Dog mod uses the same script file for BG1 and SoD).</p>	  
+	  <p>Still, there needs to be some specification whether Korlasz' Crypt needs to be treated like SoD or like BG1 content with respect to interaction with original NPCs as described above.</p>
+      <p class="info">An easy way to detect SoD in a BG:EE+SoD game is by using the unique variable "bd_plot". It is set to "2" at the beginning of the SoD intro cutscene (where the two followers of Korlasz are talking beside the chasm: "Sarevok's dead. Everything's a mess. We should have gotten out of the city days ago.") and will be increased to "40" when Korlasz' Dungeon is done. After finishing Korlasz' Crypt and the PC being woken up by Imoen in the Ducal Palace, the check variable for SoD would be "GlobalGT("BD_PLOT","GLOBAL",50)". Example code how to use this to our advantage is given below.</p>	  
+	  <p>To ensure compatibility with both SoD's and "BG1's" Korlasz' Crypt you need to consider the following for any content you add to it:</p>
+	  <p><strong>1. NPC Banter indide Korlasz' Crypt</strong></p>
+	  <p>To make sure your NPC does not start banter that will break, Korlasz' Dungeon needs to be included or excluded from BG1 content dependent on whether EndlesssBG1 or Transitions mod is installed or not, because:</p>
+	  <ol>
+        <li>Original NPCs will use their SoD banter file (if assigned) if Korlasz' Crypt is in SoD.</li>
+        <li>Original NPCs will use their BG1 banter file inside Korlasz' Crypt if it is in BG1. (This is due to engine structure.)</li>
+      </ol>
+	  <p>For this, I defined the variables "IT_IS_SOD" and "BG1_BEFORE_TRANSITION" with the following definitions. Put this into the ALWAYS block of your mod: </p>
 	  <pre class="code">
-/* xxbdintro.baf
-transition from BG:EE to SoD: change Biff's Joined dialogue and OVERRIDE script */
-IF
-	Global("SOD_fromimport","global",1)
-	InMyArea("xxBiff")  
-THEN
-	RESPONSE #100
-		CutSceneId(Player1)
-		ActionOverride("xxBiff",SetDialog("xxBiffJ")) //Biff's SoD joined dialogue
-		ActionOverride("xxBiff",ChangeAIScript("xxBiffs",OVERRIDE)) //Biff's SoD script
+/* (T1) Definition of variables to distinguish between SoD and BG1 (for banter or script blocks) */
+ACTION_IF (GAME_IS ~bgee~) THEN BEGIN
+  ACTION_IF (MOD_IS_INSTALLED ~c#endlessbg1.tp2~ ~14~) BEGIN
+    OUTER_SPRINT ~BG1_BEFORE_TRANSITION~ ~GlobalLT("BD_PLOT","GLOBAL",41)~
+    OUTER_SPRINT ~IT_IS_SOD~ ~GlobalGT("bd_plot","global",40)~
+  END ELSE ACTION_IF (MOD_IS_INSTALLED ~transitions.tp2~ ~0~) BEGIN
+    OUTER_SPRINT ~BG1_BEFORE_TRANSITION~ ~GlobalLT("BD_PLOT","GLOBAL",41)~
+    OUTER_SPRINT ~IT_IS_SOD~ ~GlobalGT("bd_plot","global",40)~
+  END ELSE BEGIN
+    OUTER_SPRINT ~BG1_BEFORE_TRANSITION~ ~Global("BD_PLOT","GLOBAL",0)~
+    OUTER_SPRINT ~IT_IS_SOD~ ~GlobalGT("bd_plot","global",0)~
+  END
 END
-	  </pre>
-	  <p>With the line for patching in the tp2 (note the EXTEND_TOP):</p>
-      <pre class="code">
-/* transition from BG:EE to SoD: change Biff's Joined dialogue and OVERRIDE script */
-EXTEND_TOP ~bdintro.bcs~ ~%MOD_FOLDER%/baf/xxbdintro.baf~
-  EVALUATE_BUFFER
-</pre>
+ACTION_IF GAME_IS ~eet~ THEN BEGIN
+  ACTION_IF (MOD_IS_INSTALLED ~c#endlessbg1.tp2~ ~14~) BEGIN
+    OUTER_SPRINT ~BG1_BEFORE_TRANSITION~ ~OR(2) Global("ENDOFBG1","GLOBAL",0) GlobalLT("BD_PLOT","GLOBAL",41)~
+    OUTER_SPRINT ~IT_IS_SOD~ ~Global("ENDOFBG1","GLOBAL",1) GlobalGT("bd_plot","global",40)~
+  END ELSE ACTION_IF (MOD_IS_INSTALLED ~transitions.tp2~ ~0~) BEGIN
+    OUTER_SPRINT ~BG1_BEFORE_TRANSITION~ ~OR(2) Global("ENDOFBG1","GLOBAL",0) GlobalLT("BD_PLOT","GLOBAL",41)~
+    OUTER_SPRINT ~IT_IS_SOD~ ~Global("ENDOFBG1","GLOBAL",1) GlobalGT("bd_plot","global",40)~
+  END ELSE BEGIN
+    OUTER_SPRINT ~BG1_BEFORE_TRANSITION~ ~Global("ENDOFBG1","GLOBAL",0)~
+    OUTER_SPRINT ~IT_IS_SOD~ ~Global("ENDOFBG1","GLOBAL",1)~
+  END
+END
+	  </pre>	  
+	  <p>Using the variables is easy: tagg the BG1 banter with %BG1_BEFORE_TRANSITION% and any SoD ones with %IT_IS_SOD% and they will trigger correctly inside Korlasz' Dungeon, as well. You can also use one OVERRIDE script for BG1 and SoD and tagg the script blocks accordingly, ensuring that no script action meant for BG1 will trigger in SoD and vice versa. This tutorial assumes that your NPC uses a separate SoD script, so there will be no taggs in the examples.</p>
+      <p class="info">Note that original SoD handles banters differently than just adding banters into the banter.dlgs. See Modding Tutorial Part 4: "SoD Banter System for Your NPC" for more details.</p>	
+	  
+	  <p><strong>2. Adding interjections to original NPCs</strong></p>	  
+	  <p>Original NPCs will use their SoD joined dialogue inside Korlasz' Crypt, no matter whether it is in SoD or BG1 "world". This is ensured by EndlessBG1 to keep compatibility with the original content of NPC interjections into dialogues inside the crypt.</p>
+	  
+	  <p><strong>3. Adding other content for original NPCs</strong></p>	  
+	  <p>Original NPCs will also have their SoD OVERRIDE scripts assigned in Korlasz' Dungeon. If they do not have one for SoD, the OVERRIDE slot will be empty.</p>
+	  
+	  
+	  
       <h2><a name="toc_2b">2. Add Biff to Corwin's list about companions in BG city</a></h2>
-      <p>When leaving for Baldur's Gate city, Corwin mentions that the Flaming Fist tracked down some of CHARNAME's former companions. The PC can ask about them and Corwin lists them in case they are in BG city starting in <strong>state 39 of bdschael.dlg</strong>. This is also the dlg state we will patch our NPC to, assuming they and the PC already met, either in BG:EE or they were in Korlasz' crypt together.</p> 
+      <p>When leaving for Baldur's Gate city, Corwin mentions that the Flaming Fist tracked down some of CHARNAME's former companions. The PC can ask about them and Corwin lists them in case they are in BG city starting in <strong>state 39 of bdschael.dlg</strong>. This is also the dlg state we will patch our NPC to, assuming they and the PC already met, either in BG:EE or they were in Korlasz' Crypt together.</p> 
 	  <p>This is before the PC gets out into the city the first time. If the PC doesn't talk to Corwin here, the addition will be lost: Corwin also mentions the NPCs if talked to outside the Palace. The problem here is how to fit in another mod NPC while keeping compatibility - inserting one here would be no problem, but as soon as two mods want to do it, one of them will be skipped in the further conversation, because the whole thing is a mixture of parallel and looping dialogue states where all NPCs would need to be considered by reply options - for EET even more since it also considers whether some NPCs are already dead. That is why I only show the patching of the one dialogue state here.</p>
-	  <p>First, we add an EXTEND_BOTTOM which will give true in case the PC knows our NPC. For Biff, I will use "BeenInParty" (which is an example only, because Biff wasn't available yet, but your NPC might). Then, we add the new dialogue state where Corwin tells about Biff. To this dialogue state we will patch all transactions from state 39 so the original cycle of mentioned NPCs - plus any mod NPCs added before Biff - will go on.</p>
+	  <p>We add an I_C_T where Corwin tells about Biff with the global check variable "xxBiff_bdschael_39" which will give true in case the PC knows our NPC. For Biff, I will use "BeenInParty" (which is an example only, because Biff wasn't available yet, but your NPC might). We also check whether the NPC is dead or in party.</p>
 	  <pre class="code">
 /* This goes into a .d file: Make Corwin mention Biff's whereabouts in BG city */
-EXTEND_BOTTOM bdschael 39
-IF ~!Dead("xxBiff") !InPartyAllowDead("xxBiff") BeenInParty("xxBiff")~ THEN + mynpc
+I_C_T bdschael 39 xxBiff_bdschael_39
+== bdschael IF ~!Dead("xxBiff") !InPartyAllowDead("xxBiff") BeenInParty("xxBiff")~ THEN ~Also, Biff the Understudy was seen right in front of the Ducal Palace's gates not long ago.~
 END
-
-APPEND bdschael
-
-IF ~~ THEN mynpc
-SAY ~Also, Biff the Understudy was seen right in front of the Ducal Palace's gates not long ago.~
-COPY_TRANS bdschael 39 //This will add all transactions from bdschael.dlg state 39 here, so nothing of the original gets lost (also none of the mods installed before Biff)
-END
-
-END //APPEND
 </pre>	  
-      <h2><a name="toc_2">3. Make Biff leave party after Korlasz's Crypt is cleared</a></h2>
-      <p>SoD starts with the party from BG1 being in Korlasz's Crypt, the "last follower" of Sarevok. After Korlsz's tomb is cleared, all joinable NPCs leave the group and the PC is transferred to the Ducal Palace (bd0103.are).</p>
-	  <p class="info">This you only need if your NPC was already available in BG:EE, or if you let him join in Korlasz's crypt. If your NPC joins in BG city or later, you can skip this and continue with top 4.</p>
+      <h2><a name="toc_2">3. Make Biff leave party after Korlasz' Crypt is cleared</a></h2>
+      <p>SoD starts with the party from BG1 being in Korlasz' Crypt, the "last follower" of Sarevok. After Korlsz' Crypt is cleared, all joinable NPCs leave the group and the PC is transferred to the Ducal Palace (bd0103.are).</p>
+	  <p class="info">This you only need if your NPC was already available in BG:EE, or if you let him join in Korlasz' Crypt. If your NPC joins in BG city or later, you can skip this and continue with <a href="#toc_3">Chapter 4: Moving Biff to his new meeting point in BG city</a>.</p>
       <p>This transition is done by <strong>bd0103.bcs</strong>, i.e. the area script of the Ducal Palace, 3<sup>rd</sup> floor where the PC finds him/herself. (Origially, the transition is started in bdimoen.dlg which calls bdcut00z.bcs which just transfers the whole party to bd0103.are. Then all the sorting and moving and leaving is done by bd0103.bcs.)</p>
       <p>The script bd0103.bcs does the following for BeamDog and BioWare NPCs:</p>
       <ol>
-        <li>the inventory (BACKPACK) gets transferred to the player's chest in the Ducal Palace ("PlayerChest00").</li>
+        <li>The inventory (BACKPACK) gets transferred to the player's chest in the Ducal Palace ("PlayerChest00").</li>
         <li>dead NPC get revived,</li>
         <li>NPC leave the group and vanish (2 and 3 in one script block for each NPC).</li>
       </ol>
       <p>If we would do nothing here, Biff would be treated like a multiplayer character and will just remain in the group and be inside the Ducal Palace with the PC.</p>
       <p>But Biff should not just remain in the group after the transition but behave like a "real" NPC, so we need to add script blocks for him to bd0103.bcs.</p>
       <p>The patching to bd0103.bcs to remove Biff has to be added via EXTEND_TOP, since bd0103.bcs also triggers the cutscene with Imoen approaching the PC – patching at the bottom would be too late in the game. This means that the removal of the NPCs' BACKPACK in bd0103.bcs has to be added for Biff individually, as well.</p>
+      <p class="info">For patching to scripts with EXTEND_TOP, make sure you only add script blocks that contain a Continue(), otherwise OnCreation() triggers in the script might get blocked. This is especially important for area scripts. Even if there is none in the original game, it could have been added by another mod.</p>
       <p>The xxbd0103.baf looks like this:</p>
       <pre class="code">
 /* xxbd0103.baf:
-Biff will leave the group after clearing Korlasz's tomb */
+Biff will leave the group after clearing Korlasz' Crypt */
 IF
   OR(2)
   InMyArea("xxBiff")
@@ -268,23 +296,27 @@ EXTEND_TOP ~bd0103.bcs~ ~%MOD_FOLDER%/baf/xxbd0103.baf~
 </pre>
 
       <h2><a name="toc_3">4. Moving Biff to his new meeting point in BG city</a></h2>
-      <p>Now, your NPC should be recruitable somewhere inside BG city. As an example, Biff will be waiting in front of the Ducal Palace (<strong>bd0010.are</strong>) where the PC can meet him after leaving for the first time.</p>
-      <p>This would also be the first meeting point for players who started a new SoD game. Unless, of course, you want your NPC to start in Korlasz's Tomb for a new game also, then you'll have to add them to bd0130.bcs or bd0120.bcs, instead.</p>
+      <p>Now, your NPC should be recruitable somewhere inside BG city. As an example, Biff will be waiting in front of the Ducal Palace (<strong>bd0010.are</strong>) where the PC can meet him after leaving the palace for the first time.</p>
+      <p>This would also be the first meeting point for players who started a new SoD game. Unless, of course, you want your NPC to start in Korlasz' Crypt for a new game also, then you'll have to add them to bd0130.bcs or bd0120.bcs, instead.</p>
       <p>Open Near Infinity and look at the bd0010.are (open the graphical view). Chose a good spot and note down the coordinates that NI shows at the right bottom side. Let's call them [x0.y0] for now.</p>
-      <p>Spawning Biff will be done with xxbd0010.baf which needs to be patched to <strong>bd0010.bcs</strong>. Note that we need two script blocks: one in case it's a new SoD game, and one in case Biff was already in the party (because we want the player to have him back the way he left in BG1 or Korlasz's crypt):</p>
+      <p>Spawning Biff will be done with xxbd0010.baf which needs to be patched to <strong>bd0010.bcs</strong>. Note that we need two script blocks: one in case it's a new SoD game, and one in case Biff was already in the party (because we want the player to have him back the way he left in BG1 or Korlasz' Crypt):</p>
       <pre class="code">
 /* xxbd0010.baf
 
 Biff will be waiting in front of the Ducal Palace */
 /* new SoD game */
 IF
-  Global("xxBiffSpawn","GLOBAL",0) //any variable that is true for a new game
-  Global("xxBiff_MoveCamp","MYAREA",0) //so it happens only once
+/* We consider two possibilities for detection whether Biff already existed. Chose what suits you best here. You could also chose e.g. Global("SOD_fromimport","global",0) for a new SoD game */
+  Global("xxBiffSpawn","GLOBAL",0) //SoD spawn variable
+  !BeenInParty("xxBiff") //this variable is set automatically if Biff was in Party before. 
+  Global("xxBiffSpawnBG1","GLOBAL",0) //Biff was not present in BG1 - from your BG1 potion of your NPC mod
+  Global("xxBiffSpawn","GLOBAL",0) //spawn variable for SoD
+  Global("xxBiff_MoveCamp","MYAREA",0) //so spawning here happens only once
 THEN
   RESPONSE #100
     SetGlobal("xxBiff_MoveCamp","MYAREA",1)
     SetGlobal("xxBiffSpawn","GLOBAL",1)
-    CreateCreature("xxBiff",[x0.y0],N)  //open area in NI and chose coordinates and face direction
+    CreateCreature("xxBiff",[x0.y0],S)  //open area in NI and chose coordinates and face direction. I put Biff right behind Ryphus.
     ActionOverride("xxBiff",MakeGlobalOverride())
     ChangeSpecifics("xxBiff",ALLIES)
     ActionOverride("xxBiff",ChangeAIScript("xxBiffs",OVERRIDE)) //Biff's SoD override script
@@ -299,14 +331,17 @@ END
 IF
   !Dead("xxBiff")
   !InPartyAllowDead("xxBiff")
-  BeenInParty("xxBiff") //this variable is set automatically if Biff was in Party in BG1 or SoD
-  Global("xxBiff_MoveCamp","MYAREA",0)  //so it happens only once
+  Global("xxBiffSpawn","GLOBAL",0) //SoD spawn variable
+  OR(2) //we consider two possibilities for detection whether Biff already existed. Chose what suits you best here.
+	BeenInParty("xxBiff") //this variable is set automatically if Biff was in Party in BG1 or SoD. 
+	GlobalGT("xxBiffSpawnBG1","GLOBAL",0) //Biff was present in BG1 - from your BG1 potion of your NPC mod
+  Global("xxBiff_MoveCamp","MYAREA",0)  //so spawning here happens only once
 THEN
   RESPONSE #100
     SetGlobal("xxBiff_MoveCamp","MYAREA",1)
-    SetGlobal("xxBiffSpawn","GLOBAL",1) //we set this so he will be moved to bd0101.are, not spawned anew
+    SetGlobal("xxBiffSpawn","GLOBAL",1) //we set this so we can check for it in bd0101.bcs
     MoveGlobal("bd0010","xxBiff",[x0.y0])
-    ActionOverride("xxBiff",Face(N))    //or any other direction depending on the coordinates
+    ActionOverride("xxBiff",Face(S))    //or any other direction depending on the coordinates
     ApplySpellRES("bdrejuve","xxBiff")  //completely heals and removes all spell effects
     ChangeEnemyAlly("xxBiff",NEUTRAL)
     ChangeSpecifics("xxBiff",ALLIES)
@@ -332,27 +367,42 @@ EXTEND_BOTTOM ~bd0010.bcs~ ~%MOD_FOLDER%/baf/xxbd0010.baf~ EVALUATE_BUFFER
       <h2><a name="toc_4">5. Make Biff wait outside the Ducal Palace when PC marches against crusade</a></h2>
       <p>First move: Biff should be still outside the Palace when the PC moves out against the crusaders. If your NPC was elsewhere in the city beforehand, he could wait here, now.</p>
       <p>Once the PC decides to move out against the Crusade, the area outside in front of the Ducal Palace is no longer bd0010.are, but <strong>bd0101.are</strong>. We want to meet up Biff here so he should be here, too. Note: The PC can also leave for the Crusaders without going into the city to recruit NPCs, they will be available later nontheless. So will be Biff!</p>
-      <p>So, we have three possible cases here:</p>
+      <p>So, we have two possible cases here from a technical point of view for spawning him in bd0101.are:</p>
       <ol>
-        <li>It's a new SoD game and the player didn't meet Biff yet because he didn't go into the city first but left directly for the crusade.</li>
-        <li>Biff was in party before but PC didn't meet him yet because he didn't go into the city first but left directly for the crusade.</li>
-        <li>Biff and the PC already met but Biff was told to wait.</li>
+        <li>Global("xxBiffSpawn","GLOBAL",0) is still at 0 because the player did not leave the palace to look for companions but went straight to leaving BG city with the Flaming Fist forces, but Biff was not in the game before - needs to be spawned anew.</li>
+        <li>Global("xxBiffSpawn","GLOBAL",0) is still at 0 because the player did not leave the palace to look for compagnions but went straight to leaving BG city with the Flaming Fist forces, and Biff was already in party or existed in BG1 - needs to be moved to bd0101.are, not spawned anew.</li>
+        <li>Global("xxBiffSpawn","GLOBAL",1) is at 1 meaning no matter whether Biff was present in BG1 or not, he was already spawned in front of the palace in his original SoD meeting point (we chose bd0010.are) - needs to be moved to bd0101.are, not spawned anew.</li>
       </ol>
-      <p>Points 2 and 3 need only one spawn script block in our example.</p>
+      <p>Points 2 and 3 can be handled in one spawn script block in our example.</p>
       <p>The according xxbd0101.baf which needs to be patched to <strong>bd0101.bcs</strong>:</p>
       <pre class="code">
-/* xxbd0101.baf
-1. It's a new soD game, or Biff wasn't spawned yet in SoD because the player went straight for the crusade */
+/* (T1) xxbd0101.baf // Ducal Palace, Leaving BG */
+
+/* Close the spawning/moving variable in case Biff is already in party */
+IF
+  Global("xxBiff_MoveCamp","MYAREA",0)  
+  OR(2)
+    InPartyAllowDead("xxBiff")  
+    Dead("xxBiff")
+THEN
+  RESPONSE #100
+    SetGlobal("xxBiff_MoveCamp","MYAREA",1)  
+    Continue()
+END
+
+/* 1. Biff needs to be spawned anew: Global("xxBiffSpawn","GLOBAL",0) is still at 0 because the player did not leave the palace to look for companions but went straight to leaving BG city with the Flaming Fist forces, plus Biff was not in the game before */
 IF
   !Dead("xxBiff")
   !InPartyAllowDead("xxBiff")
-  Global("xxBiffSpawn","GLOBAL",0) //true for a new SoD game or if Biff wasn't spawned in bd0010.are
-  Global("xxBiff_MoveCamp","MYAREA",0) //so it happens only once
+  !BeenInParty("xxBiff") //Biff was never in party
+  Global("xxBiffSpawnBG1","GLOBAL",0) //Biff wasn't spawned in BG1
+  Global("xxBiffSpawn","GLOBAL",0) //Biff wasn't spawned in SoD before
+  Global("xxBiff_MoveCamp","MYAREA",0) //so it happens only once in this area
 THEN
   RESPONSE #100
     SetGlobal("xxBiff_MoveCamp","MYAREA",1)
-    SetGlobal("xxBiffSpawn","GLOBAL",2) //this should be higher than in xxbd0010.baf (or the second block below will be excuted, too)
-    CreateCreature("xxBiff",[601.599],S)  //for Biff, these are same coordinates as in xxbd0010.baf since he was in front of the Palace before, too
+    SetGlobal("xxBiffSpawn","GLOBAL",1) //Biff was spawned in SoD
+    CreateCreature("xxBiff",[x0.y0],S)  //for Biff, these are same coordinates as in xxbd0010.baf since he was in front of the Palace before, too
     ActionOverride("xxBiff",MakeGlobalOverride())
     ChangeSpecifics("xxBiff",ALLIES)
     ActionOverride("xxBiff",ChangeAIScript("xxBiffs",OVERRIDE)) //Biff's SoD override script
@@ -363,19 +413,20 @@ THEN
     ActionOverride("xxBiff",SetDialog("xxBiffs")  //greeting dialogue in SoD
 END
 
-/* 2+3: Biff was in party before (e.g. as a BG:EE NPC or in SoD beginning) OR he was spawned in SoD before */
+/* 2+3: Biff needs to be moved here: he was either in party before (e.g. as a BG:EE NPC or in SoD beginning) OR he was spawned in SoD before */
 IF
   !Dead("xxBiff")
   !InPartyAllowDead("xxBiff")
-  OR(2) //One of the 2 following conditions needs to be true
+  OR(3) //One of the 3 following conditions needs to be true
 	BeenInParty("xxBiff") //this is true if Biff was in party before
+	GlobalGT("xxBiffSpawnBG1","GLOBAL",0) //Biff was already spawned in BG1
 	Global("xxBiffSpawn","GLOBAL",1) //this is true if he was already spawned in bd0010.are
-  Global("xxBiff_MoveCamp","MYAREA",0)  //so it happens only once
+  Global("xxBiff_MoveCamp","MYAREA",0)  //so this happens only once in this area
 THEN
   RESPONSE #100
     SetGlobal("xxBiff_MoveCamp","MYAREA",1)
-    SetGlobal("xxBiffSpawn","GLOBAL",2)
-    MoveGlobal("bd0101","xxBiff",[601.599])
+    SetGlobal("xxBiffSpawn","GLOBAL",1) //Biff was spawned in SoD
+    MoveGlobal("bd0101","xxBiff",[x0.y0])
     ActionOverride("xxBiff",Face(S))    //or any other direction depending on the coordinates
     ApplySpellRES("bdrejuve","xxBiff")  //completely heals and removes all spell effects
     ChangeEnemyAlly("xxBiff",NEUTRAL)
@@ -400,49 +451,21 @@ EXTEND_BOTTOM ~bd0101.bcs~ ~%MOD_FOLDER%/baf/xxbd0101.baf~
 
       <h2><a name="toc_5">6. Move Biff to first camp in Coast Way Crossing (bd1000.are)</a></h2>
       <p>So, PC is off to the first war camp, bd1000.are. Biff needs to come to the camp by himself in case he is not in party, i.e. he was left standing in front of the Ducal Palace but is supposed to follow.</p>
-      <p>As of v6, I will advice to consider spawning a new cre in this case as well. For unmodded SoD, this wouldn't be necessary, as all playing styles would lead through bd0101.are where the NPC was already spawned (please refer to xxbd0101.baf) and could now being moved using MoveGlobal(). But with upcoming mods that offer skipping parts of SoD, we need the failsafe of spawning the cre anew inside the camps, too, in case it is a new SoD game!</p>
       <p>The first war camp is in Coast Way Crossing, <strong>bd1000.are</strong>. Good-aligned NPCs usually gather near Rayphus Goodtree who is standing at [600.3725]. Evil NPCs seem to gather to the left in front of the tents, but of course you can put your NPC wherever you want. (You could even let him walk around, like Glint does.) Open the area with Near Infinity and note down the coordinates you want your NPC to wait at, we will call them [x1.y1] for now.</p>
       <p>Then we create the xxbd1000.baf with the spawn script block which needs to be patched to <strong>bd1000.bcs</strong>:</p>
       <pre class="code">
-/* xxbd1000.baf
-/* xxbd1000.baf
-Biff moves to first war camp at Coast Way Crossing, bd1000.are */
+/* xxbd1000.baf */
+/* Biff moves to first war camp at Coast Way Crossing, bd1000.are */
 
-1. It's a new soD game, or Biff wasn't spawned yet in SoD because the player uses a mod that lets skip bd0101.are (the marching out of the coalition in front of the Palace). */
+/* Move Biff here. He was already spawned at some point. */
 IF
+  Global("xxBiff_MoveCamp","MYAREA",0) //so it happens only once in this area
   !Dead("xxBiff")
   !InPartyAllowDead("xxBiff")
-  Global("xxBiffSpawn","GLOBAL",0) //true for a new SoD game
-  Global("xxBiff_MoveCamp","MYAREA",0) //so it happens only once
 THEN
   RESPONSE #100
     SetGlobal("xxBiff_MoveCamp","MYAREA",1)
-    SetGlobal("xxBiffSpawn","GLOBAL",3) //again, one higher than in xxbd0101.baf
-    CreateCreature("xxBiff",[720.3784],N)  //look up area coordinates for bd0101.are
-    ActionOverride("xxBiff",MakeGlobalOverride())
-    ChangeSpecifics("xxBiff",ALLIES)
-    ActionOverride("xxBiff",ChangeAIScript("xxBiffs",OVERRIDE)) //Biff's SoD override script
-    ActionOverride("xxBiff",ChangeAIScript("bdasc3",CLASS))
-    ActionOverride("xxBiff",ChangeAIScript("BDSHOUT",RACE))
-    ActionOverride("xxBiff",ChangeAIScript("BDFIGH01",GENERAL))  //Biff's a fighter so he gets a fighter script. Have a look at bdparty.bcs to see what other scripts are available for the different classes.
-    ActionOverride("xxBiff",ChangeAIScript("",DEFAULT))
-    ActionOverride("xxBiff",SetDialog("xxBiffs")  //greeting dialogue in SoD
-	Continue()
-END
-
-IF
-  Global("xxBiff_MoveCamp","MYAREA",0)
-  !Dead("xxBiff")
-  !InPartyAllowDead("xxBiff")
-  OR(2)
-	BeenInParty("xxBiff") //this is true if Biff was in party before
-	GlobalGT("xxBiffSpawn","GLOBAL",0)//this is true if he was already spawned before
-  GlobalLT("xxBiffSpawn","GLOBAL",3)
-THEN
-  RESPONSE #100
-    SetGlobal("xxBiff_MoveCamp","MYAREA",1)
-    SetGlobal("xxBiffSpawn","GLOBAL",3)
-    MoveGlobal("bd1000","xxBiff",[720.3784]) //same area coordinates as above
+    MoveGlobal("bd1000","xxBiff",[x1.y1]) 
     ActionOverride("xxBiff",Face(N))
     ReallyForceSpellDeadRES("bdrejuve","xxBiff")
     ChangeEnemyAlly("xxBiff",NEUTRAL)
@@ -465,7 +488,7 @@ END
 EXTEND_TOP ~bd1000.bcs~ ~%MOD_FOLDER%/baf/xxbd1000.baf~
   EVALUATE_BUFFER
 </pre>
-<p>The "Move NPC to Camp" variable gets also set in case the NPC is in party. For this, the original game uses a script block inside the bd1000.bcs which is triggered by Global("bd_move_npcs","bd1000",0). We need to patch our NPC's variable here, accordingly.</p>
+<p>The "Move NPC to Camp" variable gets also set in case the NPC is in party. For this, the original game uses a script block inside the bd1000.bcs which is triggered by Global("bd_move_npcs","bd1000",0) which does not check whether the NPCs are in party but which is later than the "spawn NPCs" script blocks. We patch our NPC's variable here, accordingly, to prevent the spawn/move script blocks to interfere later.</p>
 	<p>For this, the following is added to the <strong>tp2</strong>:</p>
 	 <pre class="code">  
 	
@@ -485,45 +508,19 @@ BUT_ONLY
 	</pre>
 
       <h2><a name="toc_6">7. Move Biff to 2<sup>nd</sup> camp in Troll Claw Woods (bd7100.are)</a></h2>
-      <p>The next camp is set in the Troll Claw Woods, <strong>bd7100.are</strong>. Look up the coordinates with NI, in this tutorial we will use the placeholder [x2.y2]. xxbd7100.baf will contain Biff's spawn script block that needs to be patched to <strong>bd7100.bcs</strong>:</p>
+      <p>The next camp is set in the Troll Claw Woods, <strong>bd7100.are</strong>. Search for fitting coordinates with Near Infinity, in this tutorial we will use the placeholder [x2.y2]. xxbd7100.baf will contain Biff's spawn script block that needs to be patched to <strong>bd7100.bcs</strong>:</p>
       <pre class="code">
 /* xxbd7100.baf: */
-/* 1. It's a new soD game, or Biff wasn't spawned yet in SoD because the player uses a mod that lets skip bd0101.are (the marching out of the coalition in front of the Palace). */
-IF
-  !Dead("xxBiff")
-  !InPartyAllowDead("xxBiff")
-  Global("xxBiffSpawn","GLOBAL",0) //true for a new SoD game
-  Global("xxBiff_MoveCamp","MYAREA",0) //so it happens only once
-THEN
-  RESPONSE #100
-    SetGlobal("xxBiff_MoveCamp","MYAREA",1)
-    SetGlobal("xxBiffSpawn","GLOBAL",4) //again, one higher than in xxbd1000.baf
-    CreateCreature("xxBiff",[351.3356],N)  //look up area coordinates for bd7100.are
-    ActionOverride("xxBiff",MakeGlobalOverride())
-    ChangeSpecifics("xxBiff",ALLIES)
-    ActionOverride("xxBiff",ChangeAIScript("xxBiffs",OVERRIDE)) //Biff's SoD override script
-    ActionOverride("xxBiff",ChangeAIScript("bdasc3",CLASS))
-    ActionOverride("xxBiff",ChangeAIScript("BDSHOUT",RACE))
-    ActionOverride("xxBiff",ChangeAIScript("BDFIGH01",GENERAL))  //Biff's a fighter so he gets a fighter script. Have a look at bdparty.bcs to see what other scripts are available for the different classes.
-    ActionOverride("xxBiff",ChangeAIScript("",DEFAULT))
-    ActionOverride("xxBiff",SetDialog("xxBiffs")  //greeting dialogue in SoD
-	Continue()
-END
 
-//2. Move him if he was already spawned before or exists from BG1
+/* Move him here. He was already spawned before or exists from BG1 */
 IF
   Global("xxBiff_MoveCamp","MYAREA",0)
   !Dead("xxBiff")
   !InPartyAllowDead("xxBiff")
-  OR(2)
-	BeenInParty("xxBiff") //this is true if Biff was in party before
-	GlobalGT("xxBiffSpawn","GLOBAL",0)//this is true if he was already spawned before
-  GlobalLT("xxBiffSpawn","GLOBAL",4)
 THEN
     RESPONSE #100
     SetGlobal("xxBiff_MoveCamp","MYAREA",1)
-    SetGlobal("xxBiffSpawn","GLOBAL",4)
-    MoveGlobal("bd7100","xxBiff",[351.3356]) //same area coordinates as above
+    MoveGlobal("bd7100","xxBiff",[x2.y2]) 
     ActionOverride("xxBiff",Face(N))
     ReallyForceSpellDeadRES("bdrejuve","xxBiff")
     ChangeEnemyAlly("xxBiff",NEUTRAL)
@@ -566,48 +563,21 @@ BUT_ONLY
 	</pre>
 
       <h2><a name="toc_7">8. Move Biff to the Coalition Camp in bd3000.are</a></h2>
-      <p>The last camp the coalition moves to is the big Coalition Camp in <strong>bd3000.are</strong>. Again, Biff will follow in case he wasn't in the party upon transition. Look up bd3000.are in NI and note down the coordinates you want your PC to wait at, we will call them [x3.y3] for this tutorial.</p>
+      <p>The last camp the coalition moves to is the big Coalition Camp in <strong>bd3000.are</strong>. Again, Biff will follow in case he wasn't in the party upon transition. Look up bd3000.are in Near Infinity and note down the coordinates you want your PC to wait at, we will call them [x3.y3] for this tutorial.</p>
       <p>xxbd3000.baf (which will be patched to <strong>bd3000.bcs</strong>) with Biff's spawn script inside the Coalition Camp:</p>
       <pre class="code">
-/* xxbd3000.baf
-Moves Biff into the Coalition Camp if he was not in party */
+/* xxbd3000.baf */
+/* Moves Biff into the Coalition Camp if he was not in party */
 
-/* 1. It's a new soD game, or Biff wasn't spawned yet in SoD because the player uses a mod that lets skip bd0101.are (the marching out of the coalition in front of the Palace). */
-IF
-  !Dead("xxBiff")
-  !InPartyAllowDead("xxBiff")
-  Global("xxBiffSpawn","GLOBAL",0) //true for a new SoD game
-  Global("xxBiff_MoveCamp","MYAREA",0) //so it happens only once
-THEN
-  RESPONSE #100
-    SetGlobal("xxBiff_MoveCamp","MYAREA",1)
-    SetGlobal("xxBiffSpawn","GLOBAL",5) //again, one higher than in xxbd7100.baf
-    CreateCreature("xxBiff",[1552.1723],N)  //look up area coordinates for bd3000.are
-    ActionOverride("xxBiff",MakeGlobalOverride())
-    ChangeSpecifics("xxBiff",ALLIES)
-    ActionOverride("xxBiff",ChangeAIScript("xxBiffs",OVERRIDE)) //Biff's SoD override script
-    ActionOverride("xxBiff",ChangeAIScript("bdasc3",CLASS))
-    ActionOverride("xxBiff",ChangeAIScript("BDSHOUT",RACE))
-    ActionOverride("xxBiff",ChangeAIScript("BDFIGH01",GENERAL))  //Biff's a fighter so he gets a fighter script. Have a look at bdparty.bcs to see what other scripts are available for the different classes.
-    ActionOverride("xxBiff",ChangeAIScript("",DEFAULT))
-    ActionOverride("xxBiff",SetDialog("xxBiffs")  //greeting dialogue in SoD
-	Continue()
-END
-
-//2. Move him if he was already spawned before or exists from BG1
+/* Move him here, he was already spawned before or exists from BG1
 IF
   Global("xxBiff_MoveCamp","MYAREA",0)
   !Dead("xxBiff")
   !InPartyAllowDead("xxBiff")
-  OR(2)
-	BeenInParty("xxBiff") //this is true if Biff was in party before
-	GlobalGT("xxBiffSpawn","GLOBAL",0)//this is true if he was already spawned before
-  GlobalLT("xxBiffSpawn","GLOBAL",5)
 THEN
   RESPONSE #100
     SetGlobal("xxBiff_MoveCamp","MYAREA",1)
-    SetGlobal("xxBiffSpawn","GLOBAL",5)
-    MoveGlobal("bd3000","xxBiff",[1552.1723]) //same area coordinates as above
+    MoveGlobal("bd3000","xxBiff",[x3.y3]) 
     ActionOverride("xxBiff",Face(N))
     ReallyForceSpellDeadRES("bdrejuve","xxBiff")
     ChangeEnemyAlly("xxBiff",NEUTRAL)
@@ -664,7 +634,7 @@ IF
 	Global("bd_move_npcs","bd3000",1)  // Allied Siege Camp
 	Global("bd_move_to_entrance","locals",0)
 	Name("xxBiff",Myself)  
-	Global("xxBiff_bd_move","bd3000",1)  // same variable as used for moving Biff here
+	Global("xxBiff_MoveCamp","MYAREA",1)  // same variable as used for moving Biff here
 THEN
 	RESPONSE #100
 		SetGlobal("bd_move_to_entrance","locals",1)
@@ -687,7 +657,7 @@ EXTEND_BOTTOM ~bdasc3.bcs~ ~%MOD_FOLDER%/baf/xxbdasc3.baf~
 	<p>For this, the following is added to the <strong>tp2</strong>:</p>
 	 <pre class="code">  
 	
-	/* Patch your NPC's "Move Camp" variable to the original game's script block (bd3000.bcs) */
+	/* Patch your NPC's "Move Camp" variable to the original game's script block (bd3000.bcs) to call back NPC when battle starts */
 COPY_EXISTING ~bd3000.BCS~ ~override~
 	DECOMPILE_AND_PATCH BEGIN
 		SPRINT textToReplace ~\(SetGlobal("bd_move_voghiln","bd3000",0)\)~
@@ -704,17 +674,17 @@ BUT_ONLY
 	
 
       <h2><a name="toc_8">10. Make Biff return to camp if told so after being kicked out in wilderness area</a></h2>
-      <p>So, Biff will move with the camps in case he was left standing, either in a camp itself or somewhere else. But there is more in the SoD scripting we can take advantage of. For example, what if we want Biff to return to the current camp when kicked out in some wilderness area? And which camp is the current one, anyway?… Fortunately, SoD has means to detect this.</p>
+      <p>So, Biff will move with the camps in case he was left standing, either in a camp itself or somewhere else. But there is more in the SoD scripting we can take advantage of. For example, what if we want Biff to return to the current camp when kicked out in some wilderness area? And which camp is the current one, anyway? - Fortunately, SoD has means to detect this.</p>
       <p>Let's have a look at <strong>bdparty.bcs</strong>. This script is set by dplayer2.bcs if an NPC is kicked out of the party in SoD. It makes every NPC talk to the PC after being kicked out (or leave if unhappy) and also sets "Global("bd_joined","locals",1)" which we will use in Biff's kickout dialogue.</p>
       <p>The script also sets the appropriate GENERAL script (depending on your NPC's class), RACE, and DEFAULT scripts and resets several local variables.</p>
-      <p>We need the following addition to <strong>bdparty.bcs</strong> to make Biff move back to the camp on his own if kicked out somewhere else. Everything else is done by the script. The used variable Global("bd_npc_camp","locals",1) which makes Biff go back to the (current) camp is set by the kickout dialogue which will be discussed below.</p>
+      <p>We need the following addition to <strong>bdparty.bcs</strong> to make Biff move back to the camp on his own if kicked out somewhere else. Everything else is done by the script. The used variable Global("bd_npc_camp","locals",1) which makes Biff go back to the (current) camp is set by the kickout dialogue which will be discussed in <a href="#toc_12">Chapter 14: "Biff's SoD kickout dialogue with the needed local variables"</a>.</p>
 	  <p class="info">Please note: Trigger overrides for objects that may not exist in the area might bug out so that is one of the reasons it is integrated into an OR trigger here. In addition, TriggerOverride needs to be the last in a condition block, i.e. switching the !Range() and !TriggerOverride() in the OR(2) block would lead to the OR-trigger to fail. This is also the case for dialogue triggers.</p>
 	  <pre class="code">
 /* xxbdparty.baf:
 Addition to bdparty.bcs to toggle moving back to the current camp if kicked out of party. */
 
 IF
-  Global("bd_npc_camp","locals",1)  //this is set via the kickout dialogue, see below
+  Global("bd_npc_camp","locals",1)  //this is set via the kickout dialogue xxBiffsP.dlg
   Name("xxBiff",Myself)
   Switch("bd_npc_camp_chapter","global")  //this makes sure the NPC goes back to the correct camp along SoD's campaign
   OR(2)
@@ -751,7 +721,7 @@ are about the only place I know where case matters." */
     ChangeAIScript("bdasc3",CLASS)
 END
 </pre>
-      <p>And for the tp2 (note the EXTEND_TOP):</p>
+      <p>And for the tp2 (note the EXTEND_TOP, since the script blocks needs to be applied early, but we do not add "Continue()" here as it might leads to bugs for our mod - this is an exception):</p>
       <pre class="code">
 /* return to camp if kicked out */
 EXTEND_TOP ~bdparty.bcs~ ~%MOD_FOLDER%/baf/xxbdparty.baf~
@@ -759,14 +729,14 @@ EXTEND_TOP ~bdparty.bcs~ ~%MOD_FOLDER%/baf/xxbdparty.baf~
 </pre>
 
       <h2><a name="toc_9">11. Make Biff follow if kicked out in Avernus</a></h2>
-      <p>We are not done with script additions yet. If kicked out in the hell dimension (in area bd4700.are to make room for Caelar), the NPC does not move directly back to camp but is moved with the party in the appropriate cutscenes <strong>bdcut58.bcs</strong> and <strong>bdcut59b.bcs</strong>.</p>
+      <p>We are not done with script additions yet. If kicked out in the hell dimension bd4700, the NPC does not move directly back to camp but is moved with the party in the appropriate cutscenes <strong>bdcut58.bcs</strong> and <strong>bdcut59b.bcs</strong>.</p>
       <p>This is the addition for Biff to bdcut58.bcs, where all characters are moved back to the portal in bd4400.are:</p>
       <pre class="code">
 /* xxbdcut58.baf
-Biff was left standing in bd4700.are - make sure he's coming to the last hell area, too */
+Biff was left standing in bd4700 - make sure he's coming to the last hell area, too */
 
 IF
-  Global("xxBiff_kicked_bd4700","global",1) //set in xxBiffsP.dlg, see below
+  Global("xxBiff_kicked_bd4700","global",1) //set in xxBiffsP.dlg
   !Dead("xxBiff")
   !InParty("xxBiff")
 THEN
@@ -785,15 +755,15 @@ EXTEND_TOP ~bdcut58.bcs~ ~%MOD_FOLDER%/baf/xxbdcut58.baf~
 
       <h2><a name="toc_10">12. Move Biff to Dragonspear Castle interior after PC returns from Avernus</a></h2>
       <p><strong>bdcut59b.bcs</strong> deals with moving PC and all NPCs – joined or left standing in Avernus - back into the Dragonspear Castle interior (<strong>bd4300.are</strong>) which is the last area before the “end game” starts where none of the other areas are accessible any more (for plain SoD). It also deals with NPCs not in party (left standing in the last camp or some wilderness area, not in Avernus) being moved here.</p>
-      <p>Thus, if Biff was kicked out of the party in Avernus (bd4700.are), the variable Global("xxBiff_kicked_bd4700","global",1) was set by the kickout dialogue xxBiffsP.dlg as shown below, and he should be near the portal (because he just came through it since he was in Avernus even without being in the party).</p>
+      <p>Thus, if Biff was kicked out of the party in Avernus (bd4700.are), the variable Global("xxBiff_kicked_bd4700","global",1) was set by the kickout dialogue xxBiffsP.dlg as shown in Chapter 14, and he should be near the portal (because he just came through it since he was in Avernus even without being in the party).</p>
       <p>For Global("xxBiff_kicked_bd4700","global",0), he can be wherever he wants to be - maybe in the room to the northeast since that's where most of the other NPCs seem to be waiting.</p>
       <p>This is what <strong>bdcut59b.bcs</strong> needs to be patched with for Biff:</p>
       <pre class="code">
-/* xxbdcut59b.baf:
-Global("xxBiff_kicked_bd4700","global",1): Biff was left standing in hell dimension - make sure he's coming back to the castle, too */
+/* xxbdcut59b.baf */
 
+/* Global("xxBiff_kicked_bd4700","global",1): Biff was left standing in hell dimension - make sure he's coming back to the castle, too */
 IF
-  Global("xxBiff_kicked_bd4700","global",1) //set in xxBiffsP.dlg, see below
+  Global("xxBiff_kicked_bd4700","global",1) //set in xxBiffsP.dlg
   !Dead("xxBiff")
   !InParty("xxBiff")
 THEN
@@ -824,7 +794,6 @@ EXTEND_TOP ~bdcut59b.bcs~ ~%MOD_FOLDER%/baf/xxbdcut59b.baf~
       <p>And that was all we needed for script patching for moving Biff until this point. Only thing missing are the according greeting dialogue xxBiffs.dlg and kickout dialogue xxBiffsP.dlg.</p>
 
       <h2><a name="toc_11">13. Biff's SoD greetings dialogue with the needed local variables</a></h2>
-      <p>What we still need is the greetings dialogue xxBiffs.dlg and the kickout dialogue xBiffP.dlg with all the used variables from above.</p>
       <p>For the SoD greeting's dialogue, the following would do.</p>
       <pre class="code">
 /* Biff's SoD greetings dialogue */
@@ -849,6 +818,11 @@ IF ~~ THEN sod_meeting_02
 END
 
 </pre>
+      <p>For the Tutorial mod package, I put this into a d-file called "xxBiffs_greetingsdialogue.d". This is the compilation in the tp2:</p>
+      <pre class="code">
+/* SoD greeting dialogue */
+COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/dialogue/xxBiffs_greetingsdialogue.d~
+</pre>
 
       <h2><a name="toc_12">14. Biff's SoD kickout dialogue with the needed local variables</a></h2>
       <p>SoD uses the kickout dialogue, joined dialogue and dream script defined in the BDDIALOG.2DA. For Biff, the SoD kickout dialogue will be xxBiffsP.dlg.</p>
@@ -858,13 +832,13 @@ END
       <p><strong>~GlobalGT("bd_npc_camp_chapter","global",1) GlobalLT("bd_npc_camp_chapter","global",5)~</strong>: time span after leaving for the crusade and before going to Avernus. This is the time where NPCs can return to a coalition camp.</p>
       <p><strong>AreaCheck("bd4700") GlobalLT("bd_plot","global",570)</strong>: in Avernus, before endfight against Belhifet</p>
       <p><strong>!Range("ff_camp",999)</strong>: “ff_camp” is the name of proximity triggers covering the camps' area (in all three camp areas)</p>
-      <p>This would do for a basic xxBiffsP.dlg:</p>
+      <p>This would do for a basic <strong>xxBiffsP.dlg</strong>.</p>
       <pre class="code">
 /* xxBiffsP.dlg Biff's kickout dialogue for SoD */
 BEGIN ~xxBiffsP~
 
-/* If kicked out in Avernus (so Caelar can join) in bd4700.are
-This sets Global("xxBiff_kicked_bd4700","global",1) which is used in xxbdcut59b.baf */
+/* If kicked out in Avernus in bd4700.are
+This sets Global("xxBiff_kicked_bd4700","global",1) which is used in xxbdcut58.baf and xxbdcut59b.baf */
 /* Biff can't go home from here - so he will stay and say something brave. */
 IF ~AreaCheck("bd4700")
     GlobalLT("bd_plot","global",570)~ THEN BEGIN kickout_1
@@ -873,12 +847,18 @@ IF ~AreaCheck("bd4700")
                  SetGlobal("bd_joined","locals",0)~ EXIT
 END
 
-/* If kicked out in Korlasz's tomb */
+/* If kicked out in Korlasz' Crypt */
 IF ~OR(2)
       AreaCheck("bd0120")
       AreaCheck("bd0130")
     GlobalGT("bd_joined","locals",0)~ THEN BEGIN kickout_2
   SAY ~You want me to go?~
+  /* commented out - this reply options doesn't *do* anything - maybe it gets fixed at some point
+  + ~OR(2)
+    !Range("ff_camp",999)
+    NextTriggerObject("ff_camp")
+    !IsOverMe("jaheira")~ THEN REPLY #%2%66314 /* ~I would. Go to the crypt entrance and wait for me there.~ */ DO ~SetGlobal("bd_npc_camp","locals",1) + kickout_3
+	*/
   ++ ~Just remain here and await my return, all right?~ + kickout_3
   ++ ~No, stay with the group.~ + kickout_4
 END
@@ -893,7 +873,7 @@ IF ~~ THEN BEGIN kickout_4
   IF ~~ THEN DO ~JoinParty()~ EXIT
 END
 
-/* kicked out somewhere else (not bd4700.are in Avernus, not Korlasz's tomb) */
+/* kicked out somewhere else (not bd4700.are in Avernus, not Korlasz' Crypt) */
 IF ~GlobalGT("bd_joined","locals",0)~ THEN BEGIN kickout_5
   SAY ~You want me to go?~
   + ~GlobalGT("bd_npc_camp_chapter","global",1)
@@ -918,11 +898,16 @@ IF ~Global("bd_joined","locals",0)~ THEN join_again
   ++ ~Just remain here and await my return, all right?~ + kickout_3
 END
 </pre>
-      <p>And that would be all – for now. What is still missing is the moving around and commenting on the events of Biff in the cutscenes at the end of SoD. I am planning on writing a tutorial for that, too.</p>
+      <p>For the Tutorial mod package, I put this into a d-file called "xxBiffsP_kickoutdialogue.d". This is the compilation in the tp2:</p>
+      <pre class="code">
+/* SoD kickout dialogue */
+COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/dialogue/xxBiffsP_kickoutdialogue.d~
+</pre>
+      <p>How to move etc. your NPC from this point on in the cutscenes at the end of SoD will be explained in Modding Tutorial Part 2: Make Your NPC Comment and Move Along at the End of SoD.</p>
 	  
-      <h2><a name="toc_13">16. Credits, Used Tools, and Helpful Links</a></h2>
+      <h2><a name="toc_13">15. Credits, Used Tools, and Helpful Links</a></h2>
 	  <p>Thank you to Argent77 for turning this tutorial into a html file!</p>
-	  <p>Used Tools:</p
+	  <p>Used Tools:</p>
       <p><a href="https://github.com/Argent77/NearInfinity/releases/latest">Near Infinity</a></p>
 	  <p><a href="https://gibberlings3.github.io/iesdp/index.htm">IESDP</a></p>
       <p><a href="http://tools.stefankueng.com/grepWin.html">grepWin</a></p>
@@ -937,10 +922,13 @@ END
       <p><a href="http://forums.blackwyrmlair.net/index.php?showtopic=113">Prefix Reservation at Black Wyrm Lair Forums</a></p>
 	  
 	  
-      <h2><a name="toc_14">17. Version History</a></h2>
+      <h2><a name="toc_14">16. Version History</a></h2>
           <p>Version 8:</p>
           <ul>
-            <li>Content list corrected.</li>
+            <li>Rewritten first section for compatibility with EndlessBg1 mod. New title: "General throughts to transition into SoD "Korlasz' Crypt"".</li>
+            <li>Chapter 2 "Add Biff to Corwin's list about companions in BG city" now uses I_C_T directly.</li>
+            <li>Tutorial revised and updated with new content. Also have a close look at the used variables, as they changed in some cases.</li>
+            <li>Content list order corrected.</li>
           </ul>
           <p>Version 7:</p>
           <ul>

--- a/docs/Tutorial_NPCMoveCampsSoD.html
+++ b/docs/Tutorial_NPCMoveCampsSoD.html
@@ -110,14 +110,14 @@
     <div id="wrap"> <!-- Start content wrapper -->
       <h1>Modding Tutorial Part 1: Automatic Transition of NPCs into SoD and between Camps in SoD</h1>
 	  
-	<p>Version 7, by jastey</p>
+	<p>Version 8, by jastey</p>
 
       <div id="toc">
         <h2><a name="toc">Contents</a></h2>
         <ol class="toc">
           <li><a href="#toc_1">Transition into SoD: change Biff's OVERRIDE script to the SoD one for a continuous BG:EE-SoD game</a></li>
-          <li><a href="#toc_2">Make Biff leave party after Korlasz's Crypt is cleared</a></li>
           <li><a href="#toc_2b">Add Biff to Corwin's list about companions in BG city</a></li>
+          <li><a href="#toc_2">Make Biff leave party after Korlasz's Crypt is cleared</a></li>
           <li><a href="#toc_3">Moving Biff to his new meeting point in BG city</a></li>
           <li><a href="#toc_4">Make Biff wait outside the Ducal Palace when PC marches against crusade</a></li>
           <li><a href="#toc_5">Move Biff to first camp in Coast Way Crossing (bd1000.are)</a></li>
@@ -938,6 +938,10 @@ END
 	  
 	  
       <h2><a name="toc_14">17. Version History</a></h2>
+          <p>Version 8:</p>
+          <ul>
+            <li>Content list corrected.</li>
+          </ul>
           <p>Version 7:</p>
           <ul>
             <li>Removed remnants in description.</li>

--- a/docs/Tutorial_NPCMoveCampsSoD.html
+++ b/docs/Tutorial_NPCMoveCampsSoD.html
@@ -115,7 +115,7 @@
       <div id="toc">
         <h2><a name="toc">Contents</a></h2>
         <ol class="toc">
-          <li><a href="#toc_1">General throughts to transition into SoD "Korlasz' Crypt"</a></li>
+          <li><a href="#toc_1">General throughts to transition into SoD's "Korlasz' Crypt"</a></li>
           <li><a href="#toc_2b">Add Biff to Corwin's list about companions in BG city</a></li>
           <li><a href="#toc_2">Make Biff leave party after Korlasz' Crypt is cleared</a></li>
           <li><a href="#toc_3">Moving Biff to his new meeting point in BG city</a></li>
@@ -186,7 +186,7 @@
         </tr>
       </table>
 	  
-	  <h2><a name="toc_1">1. General throughts to transition into SoD "Korlasz' Crypt"</a></h2>
+	  <h2><a name="toc_1">1. General throughts to transition into SoD's "Korlasz' Crypt"</a></h2>
       <p class="info">This section is only of interest if your NPC was also available in BG:EE. If your NPC is a pure SoD NPC that will wait after the transition into the palace, you can skip this section.</p>
       <p class="info">Please be aware that my tutorials assume that your mod NPC uses the same joined dialogue in SoD like they use in the BG1 part of the game. If you are using a different joined dialogue for the SoD part, not only compatibility with EndlessBG1's and Transitions' "Korlasz' Crypt is in BG1" content will require special handling, but also examples in my tutorial mod about patching bddialog.2da etc. will need to be adjusted.</p>
 	  <p>After the end of BG:EE, the transition to SoD is done first by the cutscene "bdsodtrn.bcs" (triggered by Sarevok's death in AR0125.bcs) which sets the Global("SOD_fromimport","GLOBAL",1) with which the continuous game will be detected later, resurrects and completely heals all NPCs, and starts the SoD campaign ("MoveToCampaign("SoD")"). After that, the bd0120.bcs does party rearrangements depending on who is present (change Viconia's portrait, remove Imoen from the party, substituting her with Safana in case the party lacks a thief with either open locks or detect traps ability etc.) and calls the cutscene bdintro.bcs, which makes newly spawned replacement NPCs join the party and sets the NPCs override scripts and dialogues to the SoD ones.</p>
@@ -307,7 +307,6 @@ Biff will be waiting in front of the Ducal Palace */
 /* new SoD game */
 IF
 /* We consider two possibilities for detection whether Biff already existed. Chose what suits you best here. You could also chose e.g. Global("SOD_fromimport","global",0) for a new SoD game */
-  Global("xxBiffSpawn","GLOBAL",0) //SoD spawn variable
   !BeenInParty("xxBiff") //this variable is set automatically if Biff was in Party before. 
   Global("xxBiffSpawnBG1","GLOBAL",0) //Biff was not present in BG1 - from your BG1 potion of your NPC mod
   Global("xxBiffSpawn","GLOBAL",0) //spawn variable for SoD
@@ -925,9 +924,9 @@ COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/dialogue/xxBiffsP_kickoutdialogue.d~
       <h2><a name="toc_14">16. Version History</a></h2>
           <p>Version 8:</p>
           <ul>
-            <li>Rewritten first section for compatibility with EndlessBg1 mod. New title: "General throughts to transition into SoD "Korlasz' Crypt"".</li>
+            <li>Tutorial was revised and updated with new content. This includes unification of used naming schemes, correction of typos and oversights. Proposed examples might have changed in details.</li>
+            <li>Rewritten first section for compatibility with EndlessBG1 mod. New title: General throughts to transition into SoD's "Korlasz' Crypt".</li>
             <li>Chapter 2 "Add Biff to Corwin's list about companions in BG city" now uses I_C_T directly.</li>
-            <li>Tutorial revised and updated with new content. Also have a close look at the used variables, as they changed in some cases.</li>
             <li>Content list order corrected.</li>
           </ul>
           <p>Version 7:</p>

--- a/docs/Tutorial_NPC_SoDGameEnd.html
+++ b/docs/Tutorial_NPC_SoDGameEnd.html
@@ -110,7 +110,7 @@
     <div id="wrap"> <!-- Start content wrapper -->
       <h1>Modding Tutorial Part 2: Make Your NPC Comment and Move Along at the End of SoD</h1>
 	  
-	<p>Version 6, by jastey</p>
+	<p>Version 7, by jastey</p>
 
       <div id="toc">
         <h2><a name="toc">Contents</a></h2>
@@ -517,13 +517,17 @@ END
 	  
 	  
       <h2><a name="toc_13">10. Version History</a></h2>
-          <p>Version 6:</p>
+          <p>Version 7:</p>
           <ul>
-            <li>added chapter "8. If Biff should NOT be present after the PC escapes the prison"</li>
-			<li>Chapter 3. Biff visits the PC in Prison expanded in case the NPC should visit as a love interest after Corwin.</li>
+            <li>Tutorial was revised and updated with new content. This includes unification of used naming schemes, correction of typos and oversights. Proposed examples might have changed in details.</li>
+			<li>Chapter 3 "Biff visits the PC in Prison" expanded in case the NPC should visit as a love interest after Corwin.</li>
             <li>Added Continue() to script additions via EXTEND_TOP except cutscenes.</li>
             <li>Revised the order of actions in some script blocks.</li>
 			<li>Corrected typos and oversights.</li>
+          </ul>
+          <p>Version 6:</p>
+          <ul>
+            <li>Added chapter 8 "If Biff should NOT be present after the PC escapes the prison"</li>
           </ul>
           <p>Version 5:</p>
           <ul>

--- a/docs/Tutorial_NPC_SoDGameEnd.html
+++ b/docs/Tutorial_NPC_SoDGameEnd.html
@@ -128,7 +128,7 @@
         </ol>
       </div>
 
-      <p class="info">This tutorial deals with how to integrate your NPC into the events and cutscenes at the end of SoD. Biff the Understudy will be the example NPC in this guide.</p>
+      <p class="info">This tutorial deals with how to integrate your NPC into the events and cutscenes at the end of SoD. Biff the Understudy will be the example NPC in this guide. Note: I gave up on integrating the NPC at the end cutscene, so this tutorial is not helpful if you want to have your NPC walk alongseide the PC in the abduction scene. The former chapters regarding this are still in for reference, though.</p>
 	  <p class="info">Note: This tutorial contains heavy SoD spoilers.</p>
       <p><strong>Some nomenclature:</strong></p>
       <table>
@@ -140,7 +140,7 @@
         </tr>
         <tr>
           <td>xxBiff</td>
-          <td>Biff's script name (death variable)</td>
+          <td>Biff's scriptname (death variable)</td>
         </tr>
         <tr>
           <td>xxBiffs.bcs</td>
@@ -158,7 +158,7 @@
 	  <p>The first of the cutscenes leading to Skie's death and the accusations towards the PC is the cutscene where the Hooded Man makes the PC believe they killed Skie. At the end of this scene, when the Flaming Fist accuses the PC of being a murderer, all NPCs come into the room and some of them comment on what happened. Up to that point, all NPC of the group are handled by the cutscenes directly (bdcut60a.bcs and bdcut60b.bcs) and no further patching is needed, unless you want your NPC to participate even if they are not in the group.</p> 
 	  <p>We look at Biff being part of the group now. As already said, some NPCs give a comment on the murder scene. Actually, all of the NPCs have a comment, but it is scripted so there is a 50% chance of each whether they comment or not.</p> 
 	  <p>Also, there is two different possible comments with regard to whether the NPCs believe in the PC's guilt or innocence, depending on the PC's reputation. Of course, for your own NPC, you could trigger positive or negative reactions depending on what you like (romance / friendship status, custom count of good deeds, etc.) if you do not want to restrict it to reputation alone.</p>
-	  <p>The comments are handled in <strong>bd4100.bcs</strong></p> where we add the following xxbd4100.baf for Biff:
+	  <p>The comments are handled in <strong>bd4100.bcs</strong> where we add the following xxbd4100.baf for Biff:</p>
       <pre class="code">
 /* xxbd4100.baf. CHARNAME is accused of murder. Biff comments */
 
@@ -175,7 +175,8 @@ THEN
 	RESPONSE #100
 		SetGlobal("xxBiff_SoDMurderAccusations","bd4100",1)
 		SetGlobalTimer("bd_mdd1352_ot_timer","bd4100",ONE_ROUND) //set the timer according to how long the comment is. ONE_ROUND equals ONE_MINUTE = 6 seconds realtime. You can put in the amount of realtime seconds as a number directly.
-		DisplayStringHead("xxBiff",~Well, &lt;CHARNAME&gt; might have not been the friendliest, but I know the script so... Nope, I don't think &lt;PRO_HESHE&gt; did it.~)  
+		DisplayStringHead("xxBiff",~Well, &lt;CHARNAME&gt; might have not been the friendliest, but I know the script so... Nope, I don't think &lt;PRO_HESHE&gt; did it.~)   
+		Continue()
 END
 
 /* second script block: Biff makes a comment in case of higher reputation */
@@ -191,7 +192,8 @@ THEN
 	RESPONSE #100
 		SetGlobal("xxBiff_SoDMurderAccusations","bd4100",1)
 		SetGlobalTimer("bd_mdd1352_ot_timer","bd4100",ONE_ROUND)
-		DisplayStringHead("xxBiff",~Whoa, &lt;CHARNAME&gt;'s such a nice fellow. (And I know the script so... Nope, I don't think &lt;PRO_HESHE&gt; did it.)~)  
+		DisplayStringHead("xxBiff",~Whoa, &lt;CHARNAME&gt;'s such a nice fellow. (And I know the script so... Nope, I don't think &lt;PRO_HESHE&gt; did it.)~)   
+		Continue()
 END
 
 </pre>
@@ -219,9 +221,9 @@ IF
 THEN
 	RESPONSE #100
 		CutSceneId("xxBiff")
-		ActionOverride("xxBiff",LeaveParty())
 		SetGlobal("xxBiff_SoDparty_epilogue","GLOBAL",1) //This will make Biff appear after the PC was released from prison.
 		SetGlobal("xxBiff_Kickout","GLOBAL",1) //this is for inner mod detection, for example if the game's a continuous EET game. Put here whatever you need for your own mod.
+		ActionOverride("xxBiff",LeaveParty())
 		ActionOverride("xxBiff",DestroyAllFragileEquipment(ADAMANTINE)) //this destroys all drow equipment, just in case the NPC had any.
 END
 </pre>
@@ -235,11 +237,17 @@ EXTEND_TOP ~bdcut61.bcs~ ~%MOD_FOLDER%/baf/xxbdcut61.baf~
 
 
       <h2><a name="toc_2b">3. Biff visits the PC in Prison</a></h2>
-      <p>While in prison, the PC gets some visits depending on romance status of NPCs. The order of visits is the following: First Corwin, if Corwin is not romance interest, then the romance interest will come to visit next, then the "Hooded Man", and finally whoever lets the PC escape (depending on which ending the player gets).</p>
-	  <p>The example below will show how to let Biff visit the PC in prison as the first NPC. The area in question is bd0104.are and the script triggering the visits is <strong>bd0104.bcs</strong>.</p> 
-	  <p>This is what we patch to bd0104.bcs:</p>
+      <p>While in prison, the PC gets some visits depending on romance status of NPCs. The order of visits is the following: First Corwin who will come always, if Corwin is no romance interest then the romance interest will come to visit next, then the "Hooded Man", and finally whoever lets the PC escape (depending on which ending the player gets).</p>
+	  <p>The example below will show how to let Biff visit the PC in prison for two cases:</p>	  
+	  <ol>
+        <li>As the first NPC, in case your NPC should come in addition to all other visitors.</li>
+        <li>As the PC's love interest (after Corwin so the original order is preserved). This is coded so it should work for more than one love interest in case of a "multi romance" tweak.</li>
+	  </ol>
+	  <p>The area in question is bd0104.are and the script triggering the visits is <strong>bd0104.bcs</strong>. This is what we patch to bd0104.bcs:</p>
       <pre class="code">
-/* xxbd0104.baf : Biff visits the PC in prison (as first NPC) */
+/* xxbd0104.baf : Biff visits the PC in prison */
+
+/* As the first NPC, in case your NPC should come in addition to all other visitors. */
 IF
 	Global("chapter","global",13)
 	!GlobalTimerNotExpired("bd_jail_visitors_timer","bd0104")
@@ -250,12 +258,32 @@ IF
 	!Dead("xxBiff")  
 THEN
 	RESPONSE #100
-		SetGlobal("xxBiff_jail_visitors","bd0104",1)
-		SetGlobalTimer("bd_jail_visitors_timer","bd0104",FIVE_ROUNDS)
-		SetGlobalTimer("bd_jail_visitors2_timer","bd0104",TEN_ROUNDS)
+		SetGlobal("xxBiff_jail_visitors","bd0104",1) //trigger variable for Bifff's dialogue
+		SetGlobalTimer("bd_jail_visitors_timer","bd0104",FIVE_ROUNDS) //timer  needed so some other stuff will wait
+		SetGlobalTimer("bd_jail_visitors2_timer","bd0104",TEN_ROUNDS) //timer  needed so some other stuff will wait
 		MoveGlobal("bd0104","xxBiff",[720.620])  //coordinates true for all visiting NPCs
 		ActionOverride("xxBiff",ChangeAIScript("bdvisit",OVERRIDE)) //this script will handle the "NPC walks up to the PC's prison door and initiates dialogue"
+		Continue()
 END
+
+/* ## -- commented out - Biff doesn't have a romance. Enable this as appropriate
+/* As the PC's love interest (after Corwin so the original order is preserved). */
+IF
+	Global("chapter","global",13)
+	GlobalTimerExpired("bd_jail_visitors_timer","bd0104")  // Flaming Fist HQ
+	Global("bd_jail_visitors","bd0104",4)  //This calls romance interests if there are any
+	Global("xxBiff_sod_romanceactive","global",2) //your NPC's romance variable
+	!Dead("xxBiff")  
+THEN
+	RESPONSE #100
+		SetGlobal("xxBiff_jail_visitors","bd0104",1) //trigger variable for Bifff's dialogue
+		SetGlobal("bd_jail_visitors","bd0104",5)  // Flaming Fist HQ
+		SetGlobalTimer("bd_jail_visitors2_timer","bd0104",TEN_ROUNDS)  //timer  needed so some other stuff will wait
+		MoveGlobal("bd0104","xxBiff",[720.620])  //coordinates true for all visiting NPCs
+		ActionOverride("xxBiff",ChangeAIScript("bdvisit",OVERRIDE)) //this script will handle the "NPC walks up to the PC's prison door and initiates dialogue"
+		Continue()
+END
+## */
 	  </pre>
 	  <p>To patch xxbd0104.baf to bd0104.bcs, we need this line in the tp2 (note the EXTEND_TOP):</p>
       <pre class="code">
@@ -263,16 +291,20 @@ END
 EXTEND_TOP ~bd0104.bcs~ ~%MOD_FOLDER%/baf/xxbd0104.baf~
   EVALUATE_BUFFER
 </pre>
-     <p>The dialogue goes into a .d-file. Again, Biff is not in the group, so we use his kickout dialogue xxBiffsP.dlg:</p>
+     <p>Biff is not in the group, so we use his kickout dialogue xxBiffsP.dlg. The variable structure will work for either case (Biff being additional first visitor or love interest). The dialogue goes into a .d-file (in the tutorial mod package I put it into a general "sod_event_comments.d" which also contains other content from the other Tutorial Parts but you can put it in any other d-file as well):</p>
 	 <pre class="code">
 /* (T2) Biff visits PC in prison */
-
 APPEND xxBiffsP 
-
 IF WEIGHT #-1 //we make this higher weighted so it triggers instead of his valid kickout dialogue
 ~Global("xxBiff_jail_visitors","bd0104",1)~ THEN prison_visit
 SAY ~Hey there, &lt;CHARNAME&gt;. I know it sounds weird, but... you'll be fine, so hang in there, alright?~
+/* non-romance case */
 IF ~~ THEN DO ~SetGlobal("xxBiff_jail_visitors","bd0104",2) 
+SetGlobal("bd_visit_player","locals",1) //this will let Biff EscapeArea() via bdvisit.bcs
+~ EXIT
+/* romance case: */
+IF ~Global("bd_jail_visitors","bd0104",5)~ THEN DO ~SetGlobal("xxBiff_jail_visitors","bd0104",2) 
+SetGlobal("bd_jail_visitors","bd0104",4) //for romance case, we reset the variable to "4" so other romance interests can show - if present. If none is present, the script bd0104.bcs will move on.
 SetGlobal("bd_visit_player","locals",1) //this will let Biff EscapeArea() via bdvisit.bcs
 ~ EXIT
 END
@@ -288,8 +320,7 @@ END //APPEND
       </ol>
       <p>The according xxbd6200.baf looks like this:</p>
       <pre class="code">
-/* end of SoD. Biff will be at the meeting place */
-
+/* End of SoD. Biff will be at the meeting place */
 IF
 	Global("chapter","global",13)
 	Global("xxBiff_SoDEndMove","bd6200",0)
@@ -297,13 +328,13 @@ IF
 	!InPartyAllowDead("xxBiff")
 	Global("xxBiff_SoDparty_epilogue","GLOBAL",1) //this is the variable that was set in the xxbdcut61.baf
 THEN
-	RESPONSE #0
+	RESPONSE #100
 		SetGlobal("xxBiff_SoDEndMove","bd6200",1)
 		SetGlobal("bd_meet_canon_party","bd6200",1) //tells Imoen that there is someone waiting at the clearing (used in her greetings dialogue at the sewer exit)
 		MoveGlobal("bd6200","xxBiff",[xxx.yyy]) //chose coordinates near the meeting place: the clearing at the southeast. For example: Minsc is waiting at [1660.1120]
 		ActionOverride("xxBiff",SetSequence(SEQ_READY)) //from IESDP: This action instructs the active creature to perform the specified animation sequence. Values are from seq.ids.
 		ActionOverride("xxBiff",Face(NW)) //depending on where the NPC stands, they should face the north east
-		ActionOverride("xxBiff",SetGlobal("bd_joined","locals",0)) //we remember these from tutorial 1
+		ActionOverride("xxBiff",SetGlobal("bd_joined","locals",0)) //we remember these from Tutorial Part 1
 		ActionOverride("xxBiff",SetGlobal("bd_retreat","locals",0))
 		ActionOverride("xxBiff",SaveObjectLocation("LOCALS","bd_default_loc",Myself))
 		ReallyForceSpellDeadRES("bdrejuve","xxBiff")  // heals and removes spell effects
@@ -343,10 +374,12 @@ EXTEND_TOP ~bd6200.bcs~ ~%MOD_FOLDER%/baf/xxbd6200.baf~
       <pre class="code">
 /* PC escaped from the prison. All NPCs say a greeting */
 I_C_T3 BDIMOEN 99 xxBiff_SoDMurderComment 
+/* PC is believed to be the murderer */
 == xxBiffsP IF ~Global("bd_player_exiled","global",0)
 !Dead("xxBiff")
 InMyArea("xxBiff")
 !InParty("xxBiff")~ THEN ~Good you made it out. Sorry about all the blood.~
+/* PC is believed to be innocent */
 == xxBiffsP IF ~!Global("bd_player_exiled","global",0)
 !Dead("xxBiff")
 InMyArea("xxBiff")
@@ -356,13 +389,13 @@ END
 
 
       <h2><a name="toc_5">6. Biff should appear in the last area (abduction scene, bd6100.are)[DEPRECATED]</a></h2>
-	  <p class="info">This section is deprecated. I'll leave it in so anyone interested can try to make this work without having to search for the involved scripts anew. I do not recommend using this the way it is described here. Problems arising for my NPC were: the NPC does not walk across the clearing in bd6100.are but remains standing under the bushes; the NPC does not appear in Irenicus' Dungeon although the script block for their creation run; the NPC appears but still has all protection effects of the last kidnapping scene on them. One possibility to circumvent the last two issues could be to work with a "dummy NPC" that walks alongside the group. I decided to not let my NPC appear in the last kidnapping scene.</p>
-      <p>After the PC and all present NPCs start moving and the scene fades to black, the cutscene <strong>bdcut64x.bcs</strong> handles the rejoining of the canon NPCs (Imoen - first time she joins in SoD!, Minsc, Dynaheir, Jaheira, Khalid) before calling bdcut65.bcs which transfers and moves the group onto bd6100.are, the final abduction area. This takes into consideration whether there is enough empty slots for the NPCs (for e.g. multiplayer game with more than one protagonist), and also whether the canon NPCs are actually still alive and present.</p>
+	  <p class="info">This section is deprecated. I'll leave it in so anyone interested can try to make this work without having to search for the involved scripts anew. I do not recommend using this the way it is described here. Problems arising for my NPC were: the NPC does not walk across the clearing in bd6100.are but remains standing under the bushes; the NPC does not appear in Irenicus' Dungeon although the script block for their creation run; the NPC appears but still has all protection effects of the last kidnapping scene on them. One possibility to circumvent the last two issues could be to work with a "dummy NPC" that walks alongside the group. I decided to not let my NPC appear in the last kidnapping scene because I lost motivation to work with this scene any more. Also note: if your NPC takes a place of one of the 5 canon party members, it can happen that the problems described above might apply to Imoen, Jaheira, or Minsc after transition to Irenicus' Dungeon in EET.</p>
+      <p>After the PC and all present NPCs start moving and the scene fades to black, the cutscene <strong>bdcut64x.bcs</strong> handles the rejoining of the canon NPCs (Imoen - first time she joins in original SoD!, Minsc, Dynaheir, Jaheira, Khalid) before calling bdcut65.bcs which transfers and moves the group onto bd6100.are, the final abduction area. This takes into consideration whether there is enough empty slots for the NPCs (for e.g. multiplayer game with more than one protagonist), and also whether the canon NPCs are actually still alive and present.</p>
 	  <p>This means, that with all canon NPCs alive (Imoen will be alive no matter what, but the other four might not be alive any more and won't be present then), the group is full with 6 people, and there is no "room" for your NPC. If there is less, then there would be room, in principle. But for easier handling of our mod NPC, we will only move Biff to teh last area and let him walk at the PC's side. This way, we only have to consider one case.</p>
 	  <p>This is what we add to bdcut64x.bcs for Biff:</p>
       <pre class="code">
 /* xxbdcut64x.baf
-Biff will not join after PC escaped from prison (simplifies scripting) */
+Biff will not join after PC escaped from prison (simplifies scripting and prevents bugs for the default NPC crew in EET) */
 IF
 	Global("xxBiff_SoDEndMove","bd6200",1) //same as in xxbd6200.bcs 
 	InMyArea("xxBiff")
@@ -372,7 +405,7 @@ THEN
 	RESPONSE #100
 		CutSceneId(Player1)
 		SetGlobal("xxBiff_SoDEndMove","bd6200",2)
-		ActionOverride("xxBiff",LeaveAreaLUA("bd6100","",[xxx.yyy],SE)) //chose some coordinates beneath the trees northseast of the clearing 
+		ActionOverride("xxBiff",LeaveAreaLUA("bd6100","",[xxx.yyy],SE)) //chose some coordinates beneath the trees northeast of the clearing 
 		SmallWait(10)
 		Continue()
 END
@@ -387,16 +420,19 @@ EXTEND_TOP ~bdcut64x.bcs~ ~%MOD_FOLDER%/baf/xxbdcut64x.baf~
 </pre>
 
       <h2><a name="toc_6">7. Biff should move with the group in the last area (abduction scene, bd6100.are)[DEPRECATED]</a></h2>
-	  <p class="info">This section is deprecated. I'll leave it in so anyone interested can try to make this work without having to search for the involved scripts anew. I do not recommend using this the way it is described here. Problems arising for my NPC were: the NPC does not walk across the clearing in bd6100.are but remains standing under the bushes; the NPC does not appear in Irenicus' Dungeon although the script block for their creation run; the NPC appears but still has all protection effects of the last kidnapping scene on them. One possibility to circumvent the last two issues could be to work with a "dummy NPC" that walks alongside the group. I decided to not let my NPC appear in the last kidnapping scene.</p>
+	  <p class="info">This section is deprecated. I'll leave it in so anyone interested can try to make this work without having to search for the involved scripts anew. I do not recommend using this the way it is described here. Problems arising for my NPC were: the NPC does not walk across the clearing in bd6100.are but remains standing under the bushes; the NPC does not appear in Irenicus' Dungeon although the script block for their creation run; the NPC appears but still has all protection effects of the last kidnapping scene on them. One possibility to circumvent the last two issues could be to work with a "dummy NPC" that walks alongside the group. I decided to not let my NPC appear in the last kidnapping scene because I lost motivation to work with this scene any more. Also note: if your NPC takes a place of one of the 5 canon party members, it can happen that the problems described above might apply to Imoen, Jaheira, or Minsc after transition to Irenicus' Dungeon in EET.</p>
       <p>In the last SoD area bd6100.are, the group emerges from beneath the trees and moves out into the clearing before the abduction happens. Biff should move, too, so we need to patch the cutscene bdcut65.bcs.</p>
-	  <p>This is what we add to the tp2 to patch bdcut65.bcs:</p>
+	  <p>This is what we add to the tp2 into the ALWAYS block:</p>
       <pre class="code">
 	  
 //put this into the ALWAYS block of cour tp2  
-INCLUDE ~ACBre/lib/extra_regexp_vars.tph~ //this makes sure REPLACE_TEXTUALLY finds the right match to patch
+INCLUDE ~%MOD_FOLDER%/lib/extra_regexp_vars.tph~ //this makes sure REPLACE_TEXTUALLY finds the right match to patch
 OUTER_SPRINT newline ~%WNL%%LNL%%MNL%%TAB% ~
 
+</pre>
 
+	  <p>This is what we add to the tp2 to patch bdcut65.bcs:</p>
+      <pre class="code">
 /* Biff should move with the group in the last area (abduction scene, bd6100.are) */
 COPY_EXISTING ~bdcut65.bcs~ ~override~
   DECOMPILE_AND_PATCH BEGIN
@@ -447,6 +483,7 @@ END
       <p>To add a reply about Biff to Imoen's dialogue, we patch it to the states bdimoen 104 (for the "not guilty" ending i.e. Global("bd_player_exiled","global",1)), and bdimoen 109 (for the "guilty" ending i.e. Global("bd_player_exiled","global",0)).</p>
       <p>We put this inside a d-file:</p>
       <pre class="code">
+/* PC can ask Imoen about Biff in last meeting if Biff will not come along */
 EXTEND_BOTTOM bdimoen 104
   + ~Global("xxBiff_SoDparty_epilogue","GLOBAL",1)~ + ~I was expecting to see Biff amongst you.~ + ask_about_biff
 END
@@ -463,7 +500,7 @@ END
 
  
 	  
-      <h2><a name="toc_12">Credits, Used Tools, and Helpful Links</a></h2>
+      <h2><a name="toc_12">9. Credits, Used Tools, and Helpful Links</a></h2>
 	  <p>Thank you to Argent77 for the html template!</p>
 	  <p>Used Tools:</p
       <p><a href="https://github.com/Argent77/NearInfinity/releases/latest">Near Infinity</a></p>
@@ -479,10 +516,14 @@ END
       <p><a href="http://forums.blackwyrmlair.net/index.php?showtopic=113">Prefix Reservation at Black Wyrm Lair Forums</a></p>
 	  
 	  
-      <h2><a name="toc_13">Version History</a></h2>
+      <h2><a name="toc_13">10. Version History</a></h2>
           <p>Version 6:</p>
           <ul>
-            <li>added paragraph "8. If Biff should NOT be present after the PC escapes the prison"</li>
+            <li>added chapter "8. If Biff should NOT be present after the PC escapes the prison"</li>
+			<li>Chapter 3. Biff visits the PC in Prison expanded in case the NPC should visit as a love interest after Corwin.</li>
+            <li>Added Continue() to script additions via EXTEND_TOP except cutscenes.</li>
+            <li>Revised the order of actions in some script blocks.</li>
+			<li>Corrected typos and oversights.</li>
           </ul>
           <p>Version 5:</p>
           <ul>

--- a/docs/Tutorial_SoDBanterSystem.html
+++ b/docs/Tutorial_SoDBanterSystem.html
@@ -110,20 +110,23 @@
     <div id="wrap"> <!-- Start content wrapper -->
       <h1>Modding Tutorial Part 4: SoD Banter System for Your NPC</h1>
 	  
-	<p>Version 2, by jastey</p>
+	<p>Version 3, by jastey</p>
 
       <div id="toc">
         <h2><a name="toc">Contents</a></h2>
         <ol class="toc">
-          <li><a href="#toc_1">Activating and Initiating the Banter: Additions to Biff's Override Script</a></li>
+          <li><a href="#toc_1">Activating and Initiating Banters: Additions to NPCs' Override Scripts</a></li>
           <li><a href="#toc_2">The Banter "Area" Script</a></li>
           <li><a href="#toc_3">Having another NPC Interject into the Banter</a></li>
-          <li><a href="#toc_4">Credits, Used Tools, and Helpful Links</a></li>
-          <li><a href="#toc_5">Version History</a></li>
+          <li><a href="#toc_4">Include Optional Component for Banters in "Dialog Style"</a></li>
+          <li><a href="#toc_100">Credits, Used Tools, and Helpful Links</a></li>
+          <li><a href="#toc_101">Version History</a></li>
         </ol>
       </div>
 
-      <p class="info">This tutorial deals with how to make your NPC banter with the other party NPCs like it is custom in SoD. In SoD, banters of party NPCs are done via floating text above their heads while the player wanders about the areas. As an example NPC, Biff the Understudy will be the NPC in this guide, bantering with Corwin.</p>
+      <p class="info">This tutorial deals with how to make your NPC banter with the other party NPCs like it is custom in SoD. In SoD, banters of party NPCs are done via floating text above their heads while the player wanders about the areas. As an example NPC, Biff the Understudy will be the NPC in this guide, bantering with Corwin two times: the first banter will be started by Biff, the second by Corwin. Read through the chapters to see how the needed files play together.</p> 
+	  <p class="info">The examples are such that the banter can be also offered in "dialogue style" like they are in BG2. How to do this as an optional component of your mod is explained in Chapter 4.</p>
+	  <p class="info">Please note: the mods EndlessBG1 and Transitions can move Korlasz' Dungeon into the BG1 campaign, meaning the NPCs (including your mod NPC) will use their BG1 banter files inside the crypt. Make sure to cover compatibility when using the banter.dlgs inside Korlasz' Crypt. Refer also to Modding Tutorial Part 1, Chapter "General throughts to NPC's joined dialoge, transition into SoD "Korlasz' Crypt", and compatibility with EndlessBG1".</p>
       <p><strong>Some nomenclature:</strong></p>
       <table>
         <col width="180" />
@@ -133,66 +136,88 @@
           <td>used as a modding prefix in this tutorial. If you don't have a prefix, check the <a href="http://www.blackwyrmlair.net/prefixes/">IE Community Filename Prefix Reservations List</a> and register one at <a href="http://forums.blackwyrmlair.net/index.php?showtopic=113">Black Wyrm Lair Forums</a>.</td>
         </tr>
           <td>xxBiff</td>
-          <td>Biff's script name (death variable)</td>
+          <td>Biff's scriptname (death variable)</td>
         </tr>
         <tr>
           <td>xxBiffs.bcs</td>
           <td>Biff's SoD override script</td>
         </tr>
         <tr>
-          <td>xxBBan01.bcs</td>
-          <td>Biff's SoD banter "area" script with Corwin</td>
+          <td>xxBiff01.bcs</td>
+          <td>Biff's SoD banter "area" script for first banter with Corwin</td>
         </tr>
+        <tr>
+          <td>xxBiff02.bcs</td>
+          <td>Biff's SoD banter "area" script for second banter with Corwin</td>
+        </tr>
+        <tr>
+          <td>xxbiffbx.2da</td>
+          <td>List of Biff's SoD banter "area" scripts, executing scripts, and conversion partner's scriptnames for automatic transformation of SoD style banters to "dialogue style" banters in Chapter 4</td>
+        </tr>
+        </tr>
+          <td>xxBiffB</td>
+          <td>Biff's banter.dlg name. Note: if Biff would be available in BG1, too, I'd use the same banter file name and tagg the banter with SoD only / BG1 only triggers. This simplifies compatibility with EndlessBG1's and Transition's "Korlasz' Dungeon in BG1" content.</td>
+        </tr>
+        <tr>
       </table>
 
-      <h2><a name="toc_1">1. Activating and Initiating the Banter: Additions to Biff's Override Script</a></h2>
-      <p>The banter is started by Biff's SoD override script xxBiffs.bcs. As an example, he will banter with Corwin.</p> 
+      <h2><a name="toc_1">1. Activating and Initiating Banters: Additions to NPCs' Override Scripts</a></h2>
+      <p>The first banter is started by Biff's SoD override script xxBiffs.bcs. As an example, he will banter with Corwin.</p> 
       <p>The following is what we put into Biff's SoD script xxBiffs.bcs:</p> 
 	  <ol>
-        <li>The first script block activates the banter and sets a timer if both Biff and Corwin are in the party.</li>
-        <li>The second script block deactivates and sets the variable back to "0" if one of them is no longer in the party.</li>
-        <li>The third script block initiates the banter by setting the GENERAL area script to a script containing our banter, which will be discussed in top 2. In this example, the banter "area" script will be called "xxBiff01".</li>
+        <li>The first script block activates the banter and sets a timer if both Biff and Corwin are in the party. It also increments a checking variable by "1". 
+		<p class="info">This variable is a global variable because it manages all interactions between Biff and Corwin, regardless of which NPC started the banter. It will be used for all banters between these two NPCs and increased accordingly. The examples reflect this by giving Biff and Corwin two banters in total so you can see the structure of how it works.</p></li>
+        <li>The second script block deactivates the timer by setting the variable back to "0" if one of the NPCs is no longer in the party.</li>
+        <li>The third script block activates the banters by incrementing the banter variable by one if the banter timer run out and the variable is active. This is an extra script block to ensure triggering of the banters will run at all times and not be accidentally "swallowed" by a mistimered other command for the NPC (player click or other script firing). Refer to Kulyok's tutorial <a href="https://forums.pocketplane.net/index.php?topic=23822.0">"How to ensure your banters always run when you want them to"</a> for more info about this scripting style.</li>
+        <li>The 4<sup>th</sup> script block initiates the (1<sup>st</sup>) banter <b>started by Biff</b> by setting the GENERAL area script to a script containing our banter, which will be discussed in top 2. In this example, the banter "area" script will be called "xxBiff01".</li>
 	  </ol>
-	<p class="info">Sidenote: of course all banters of your mod NPC could be included into the same banter "area" script file. For this, you need to give the banter that is supposed to trigger a variable the banter "area" script can see, too. The example reflects this.</p>
+	<p class="info">Sidenote: of course all banters of your mod NPC could be included into the same banter "area" script file. Also, all changes of area scripts to the custom banter scripts could be done via your NPC mod's OVERRIDE script. But: if you want to offer the SoD banters in "dialogue style" as described in Chapter 4 of this tutorial, every banter needs to be in a separate file, plus the NPC starting the banter needs to have the initiation script block in their own OVERRIDE script, to enable simple conversion into "dialogue style" of the banters. I recommend putting every banter into an own baf file and removed comments on how to use one single banter "area" script file.</p>
 	
 	 <p>The following timers are used:</p> 
 	  <ol>
         <li>The custom timer until this banter will be triggered, we will call it ("xxBiff_SoD_CorwinBTimer","LOCALS"). Note that this timer is a random number between a minimum and a maximum specified in the first script block, and that it is reset every time one of the NPCs leave the party. With this in mind, in my opinion the standard maximum of 14 ingame days might be rather long if a player tends to switch NPCs often.</li>
-        <li>("BD_NPC_BANTER","GLOBAL") - global banter timer that spaces all NPC banters in SoD. Is reset by bdbaldur.bcs if it runs out without a starting banter (random between fifteen ingame minutes (90 s realtime) and one ingame hour, i.e. 6 minutes realtime). Also gets reset by every banter call in the NPCs' scripts (FOUR_HOURS, i.e. 24 minutes realtime) and at some point in the game where apparently no banters should fire the next ingame hours.</li>
+        <li>("BD_NPC_BANTER","GLOBAL") - global banter timer that spaces all NPC banters in SoD. Is reset by bdbaldur.bcs if it runs out without a banter being started (random between fifteen ingame minutes (90 s realtime) and one ingame hour, i.e. 6 minutes realtime). Also gets reset by every banter call in the NPCs' scripts (FOUR_HOURS, i.e. 24 minutes realtime) and at some point in the game where apparently no banters should fire the next ingame hours.</li>
         <li>("BD_AREA_BANTER_DELAY","MYAREA") area-specific timer that is set by baldur.bcs (SEVEN_DAYS) every time it and the global banter timer run out. This timer has to RUN so banters will fire (NPC scripts check for GlobalTimerNotExpired("BD_AREA_BANTER_DELAY","MYAREA")).</li>
 	  </ol>
 	<p></p> 	  
 
-    <p>The Global("xxBiff_SoD_CorwinBanter_DEBUG","GLOBAL",1) in the third script block is for debugging purposes only. If you do not want to include this, leave out this variable along with the two OR(2) calls.</p> 
+    <p class="info">The global("xxBiff_SoD_CorwinBanter_DEBUG","GLOBAL",1) in the third script block is for debugging purposes only. If you do not want to include this, leave out this variable along with the two OR(2) calls.</p> 
 	
 	<p>This is what the script blocks look like in Biff's SoD script:</p>
 	<pre class="code">	  
-/* This goes into Biff's SoD script */
+/* Biff's Banters */
 
+/* Corwin */
 /* First script block: Banter activation: detect Corwin and set a timer */
 IF
 	InParty(Myself) //"Myself" is Biff since we add this to his override script
-	InParty("CORWIN")  // Biff's banter partner's script name (death variable)
-	Global("xxSoD_CorwinBanter","LOCALS",0) //this variable is for activating and initiating this banter inside this script, only. Watch the letter count (max 27 for local variables if this didn't change for EE)
+	InParty("CORWIN")  // Biff's banter partner's scriptname (death variable)
+	/* "xxBiff_SoD_CorwinBanter" is a variable for activating and initiating all banters between Biff and Corwin. It is a global variable for compatibility with changing the banters to "dialogue style" */
+	OR(2) //this example covers two banters between Biff and Corwin. Adjust as needed.
+		Global("xxBiff_SoD_CorwinBanter","GLOBAL",0) //value before first banter
+		Global("xxBiff_SoD_CorwinBanter","GLOBAL",3) //value before 2nd banter
 THEN
 	RESPONSE #100
-		SetGlobalTimerRandom("xxBiff_SoD_CorwinBTimer","LOCALS",ONE_DAY,FOURTEEN_DAYS) //Adjust the min and max timer accordingly to what you want
-		SetGlobal("xxSoD_CorwinBanter","LOCALS",1)
+		SetGlobalTimerRandom("xxBiff_SoD_CorwinBTimer","LOCALS",ONE_DAY,FOURTEEN_DAYS) //Adjust the min and max timer accordingly to what you want. We can use a local timer because all banter will be activated by Biff's script.
+		IncrementGlobal("xxBiff_SoD_CorwinBanter","GLOBAL",1)
 END
-
 
 /* Second script block: Banter deactivation in case Corwin or Biff is no longer in the party */
 IF
 	OR(2)
 		!InParty(Myself)
 		!InParty("CORWIN")  
-	Global("xxSoD_CorwinBanter","LOCALS",1)
+	OR(2)
+		Global("xxBiff_SoD_CorwinBanter","GLOBAL",1) //intermediate value for first banter
+		Global("xxBiff_SoD_CorwinBanter","GLOBAL",4) //intermediate value for 2nd banter
 THEN
 	RESPONSE #100
-		SetGlobal("xxSoD_CorwinBanter","LOCALS",0)
+		IncrementGlobal("xxBiff_SoD_CorwinBanter","GLOBAL",-1) //decreases value to "Corwin not detected"
 END
 
-/* Third script block: timer run out and banter is initiated by setting the area script to a custom script containing our banter. */
+/* Third script block: timer run out and banter variable incremented. */
+/* note: this is for ALL banters between Biff and Corwin. */
+/* activate banters */
 IF
 	OR(2) //this is for debugging purposes, remove this line if you do not want to include this possibility 
 		Global("xxBiff_SoD_CorwinBanter_DEBUG","GLOBAL",1) //this is for debugging purposes, remove this line if you do not want to include this possibility 
@@ -201,56 +226,93 @@ IF
 		Global("xxBiff_SoD_CorwinBanter_DEBUG","GLOBAL",1) //this is for debugging purposes, remove this line if you do not want to include this possibility 
 		!GlobalTimerNotExpired("BD_NPC_BANTER","GLOBAL") //this needs to stay
 	GlobalTimerNotExpired("BD_AREA_BANTER_DELAY","MYAREA")
-	Global("xxSoD_CorwinBanter","LOCALS",1)
+	OR(2)
+		Global("xxBiff_SoD_CorwinBanter","GLOBAL",1) //intermediate value for first banter
+		Global("xxBiff_SoD_CorwinBanter","GLOBAL",4) //intermediate value for 2nd banter
 	IsValidForPartyDialog(Myself) //"IsValidForPartyDialog" is working in a reliable fashion in the EE, but if you prefer you can use the wellknown "CD_STATE_NOTVALID" state check together with See() and InParty() instead.
-	IsValidForPartyDialog("CORWIN")  
+	IsValidForPartyDialog("CORWIN") //Corwin should be able to talk, too
 	!PartyRested()
 	!ActuallyInCombat()
 THEN
 	RESPONSE #100
 		BanterBlockTime(450) //From IESDP: "This action extends the time taken for the banter timer to expire. The banter timers are hardcoded and every time one expires an NPC's b****.dlg is called.". Adjust the time accordingly.
 		SetGlobalTimer("BD_NPC_BANTER","GLOBAL",FOUR_HOURS)
-		SetGlobal("xxSoD_CorwinBanter","LOCALS",2)
-//	    SetGlobal("xx_SoD_xxBiff01","MYAREA",1) //uncomment this line if you want to put all your banters into one single banter "area" script file. Setting the variable here needs to be reflected in xxBiff01.baf as stated in the comments. This is the same variable as it is used in xxBiff01.baf.
+		IncrementGlobal("xxBiff_SoD_CorwinBanter","GLOBAL",1) //increment banter variable to activate 4th banter block
+END
+
+/* 4th script block: 1st banter is initiated by setting the area script to the custom script containing our banters. */
+/* note: this is ONLY for banters started by Biff with Corwin. */
+/* initiate 1st banter */
+IF
+	Global("xxBiff_SoD_CorwinBanter","GLOBAL",2) //trigger value for first banter - will be closed in 1st banter
+	IsValidForPartyDialog(Myself) //"IsValidForPartyDialog" is working in a reliable fashion in the EE, but if you prefer you can use the wellknown "CD_STATE_NOTVALID" state check together with See() and InParty() instead.
+	IsValidForPartyDialog("CORWIN")  
+	See("CORWIN") //just to make sure the two NPCs are near by each other, probably not needed if we use "IsValidForPartyDialog"
+THEN
+	RESPONSE #100
 		SetAreaScript("xxBiff01",GENERAL) //this is the banter "area" script containing the Biff-Corwin banter.
 END
+	</pre>
+      <p>The 2<sup>nd</sup> banter will be <strong>started by Corwin:</strong>, so we put its initiation into Corwin's OVERRIDE script.</p> 
+      <p class="info">Putting the triggering script block into Corwin's OVERRIDE would not be necessary, it could be executed by Biff's OVERRIDE just as well. We put it here to enable compatibility with the option to convert the banters into "dyalogue style" as shown in chapter 4.</p>
+      <p>We patch this into Corwin's OVERRIDE script <strong>bdcorwin.bcs</strong>:</p> 
+	<pre class="code">	  
+/* 2nd banter is initiated in CORWIN's script by setting the area script to the custom script containing our banter. */
+/* initiate 2nd banter */
+IF
+	Global("xxBiff_SoD_CorwinBanter","GLOBAL",5) //trigger value for first banter - will be closed in 1st banter
+	/* "IsValidForPartyDialog" is working in a reliable fashion in the EE, but if you prefer you can use the wellknown "CD_STATE_NOTVALID" state check together with See() and InParty() instead. */
+	IsValidForPartyDialog(Myself) //"Myself" is Corwin in this script
+	IsValidForPartyDialog("xxBiff") //Biff needs to be able to talk, too.
+	See("xxBiff") //just to make sure the two NPCs are near by each other, probably not needed if we use "IsValidForPartyDialog"
+THEN
+	RESPONSE #100
+		SetAreaScript("xxBiff02",GENERAL) //this is the banter "area" script containing the 2nd Biff-Corwin banter.
+END
+	</pre>
+      <p>And the actual patching of Corwin's OVERRIDE script in the <strong>tp2</strong>:</p> 
+	<pre class="code">	  
+/* 2nd banter is initiated in CORWIN's script by setting the area script to the custom script containing our banter. */
+EXTEND_BOTTOM ~bdcorwin.bcs~ ~%MOD_FOLDER%/baf/xxBiff_corwin.baf~
+EVALUATE_BUFFER
 	</pre>
 
 
       <h2><a name="toc_2">2. The Banter "Area" Script</a></h2>
-      <p>Now we need the banter "area" script that contains the Biff-Corwin banter. The name we give it for this tutorial is "xxBiff01". Since script names are bound to a maximum letter count of 8 including your prefix, just numbering them serially for the different NPC banters might by a good idea.</p>
+      <p>Now we need the banter "area" scripts that contains the Biff-Corwin banter. The name we give the first banter for this tutorial is "xxBiff01". Since script names are bound to a maximum letter count of 8 including your prefix, just numbering them serially for the different NPC banters might be a good idea. The 2nd banter "area" script will therefore be named "xxBiff02".</p>
 	  <p>The second script block resets the area script after the banter is done.</p>
-	  <p class="info">If you prefer to put all your banters into one banter "area" script, do not forget to close the trigger variable inside the relevant banter script block. The tutorial reflects this in the comments. Also, in this case the "second" script block that resets the area script needs to be included only once at the end of the file.</p>
+	  <p>So the first banter "area" script file "xxBiff01.baf" would contain the following:</p>
+	<p class="info">Please note: this example of the first banter without Minsc's interjection is skipped and not included into the mod tutorial Package "Biff the Tutorial SoD NPC Mod". Refer to chapter 3 to see the banter that is included into the tutorial mod package.</p>
 	 <pre class="code">  
-/*  banter "area" script "xxBiff01.baf" with Biff-Corwin banter: */
+/*  banter "area" script "xxBiff01.baf" with 1st Biff-Corwin banter: */
 IF
 	InMyArea(Player1)
 	!ActuallyInCombat()
 	!GlobalTimerNotExpired("BD_BANTER_DELAY","MYAREA") //this means "timer IS expired" or "was never set yet"
-	!Global("xx_SoD_xxBiff01","MYAREA",-1) //This is how SoD does it, with one banter per file. If you want to put all banters into one file, use "GlobalGT("xx_SoD_xxBiff01","MYAREA",0)" instead, so only this banter can fire.
-	Switch("xx_SoD_xxBiff01","MYAREA") //this switches between the different RESPONSE #x depending on the variable's value ("x").
+	!Global("xxBiff_SoD_xxBiff01","MYAREA",-1) //stop the loop if the variable is at "-1"
+	Switch("xxBiff_SoD_xxBiff01","MYAREA") //this switches between the different RESPONSE #x depending on the variable's value ("x").
 THEN
-	RESPONSE #0 //This is how SoD does it, with one banter per file. 
-	//use "RESPONSE #1" instead if you want to put all banters into one file and the Global("xx_SoD_xxBiff01","MYAREA",1) was set to "1" in Biff's script (because then the variable is already at 1 when this banter script is called.)
+	RESPONSE #0 
 		DisplayStringHead("xxBiff",~I'm not sure what I should be talking about. I know all the other NPC's lines, though! Pretend I'm Minsc, yes?~)  
 		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",9) //The value given here is the time in seconds until the next NPC line is shown. Chose the value depending on the length of the sentence / audio file.
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",10) //This makes the "switch" jump to the "RESPONSE #10" for the next loop: the script is still active, the script block gets executed again, but this time, Corwin replies:
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",10) //This makes the "switch" jump to the "RESPONSE #10" for the next loop: the script is still active, the script block gets executed again, but this time, Corwin replies:
 	RESPONSE #10
-		DisplayStringHead("CORWIN",58849)  // There's no shortfall of faces deserving a good kick in this world. I'm sure we'll come across one sooner than later.
+		DisplayStringHead("CORWIN",%2%58849)  // ~There's no shortfall of faces deserving a good kick in this world. I'm sure we'll come across one sooner than later.~ - We use existing lines from here, the string numbers have to be ajusted for EET. //the "%2%" is for unifying string reference numbers for SoD and EET. Definition and use please refer to Modding Tutorial Part 3, Chapter "Training the Recruits in the Coalition Camp".
 		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",8)
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",20)
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",20)
 	RESPONSE #20
-		DisplayStringHead("xxBiff",58850)  // And then Minsc does what he does best! Hehe!
+		DisplayStringHead("xxBiff",%2%58850)  // ~And then Minsc does what he does best! Hehe!~ 
 		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",4)
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",30)
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",30)
 	RESPONSE #30
-		DisplayStringHead("corwin",58851)  // Ramble nonsensically to his pet rodent about other peoples' rears?
-		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",ONE_MINUTE) //With ONE_MINUTE = 6 seconds real time
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",40)
+		DisplayStringHead("corwin",%2%58851)  // ~Ramble nonsensically to his pet rodent about other peoples' rears?~
+		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",ONE_MINUTE) //With ONE_MINUTE = 6
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",40)
 	RESPONSE #40
-		DisplayStringHead("xxBiff",58852)  // And then Minsc will do what he does second best!
+		DisplayStringHead("xxBiff",%2%58852)  // ~And then Minsc will do what he does second best!~
 		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",4)
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",-1) //this defines the banter to end, and the wanted "loop" cycle stops. The script is still active, so the second script blocks gets executed:
+		SetGlobal("xxBiff_SoD_CorwinBanter","GLOBAL",3) // close variable after 1st banter
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",-1) //this defines the banter to end, and the wanted "loop" cycle stops. The script is still active, so the second script blocks gets executed:
 END
 
 /* second script block: deactivate this script by resetting the area script. This script block is needed once at the end of the banter "area" file. */
@@ -261,58 +323,93 @@ THEN
 		SetAreaScript("",GENERAL) //sets area script back (default is "no GENERAL script")
 END
 	</pre>
+	  <p>The second banter "area" script file "xxBiff02.baf" would contain the following. To make the example more intseresting, this dialogue will be started by Corwin, not Biff.</p>
+	 <pre class="code">  
+/*  banter "area" script "xxBiff02.baf" with 2nd Biff-Corwin banter. This banter is started by Corwin: */
+IF
+	InMyArea(Player1)
+	!ActuallyInCombat()
+	!GlobalTimerNotExpired("BD_BANTER_DELAY","MYAREA") //this means "timer IS expired" or "was never set yet"
+	!Global("xxBiff_SoD_xxBiff02","MYAREA",-1) //stop the loop of this banter if the variable is at "-1"
+	Switch("xxBiff_SoD_xxBiff02","MYAREA") //this switches between the different RESPONSE #x depending on the variable's value ("x").
+THEN
+	RESPONSE #0 
+		DisplayStringHead("CORWIN",~Som what does it feel like, being a real NPC and not only the Understudy?~)  
+		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",7) //The value given here is the time in seconds until the next NPC line is shown. Chose the value depending on the length of the sentence / audio file.
+		SetGlobal("xx_SoD_xxBiff01","MYAREA",10) //This makes the "switch" jump to the "RESPONSE #10" for the next loop.
+	RESPONSE #10
+		DisplayStringHead("xxBiff",~Wait, I don't know that line... Oh, it's a real question! Thank you! Thank you, Corwin! I feel great!~
+		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",4)
+		SetGlobal("xxBiff_SoD_CorwinBanter","GLOBAL",6) // close variable of 2nd banter - was at "5"
+		SetGlobal("xxBiff_SoD_xxBiff02","MYAREA",-1) //this defines the banter to end, and the wanted "loop" cycle stops. The script is still active, so the second script blocks gets executed:
+END
+
+/* second script block: deactivate this script by resetting the area script. This script block is needed once at the end of the banter "area" file. */
+IF
+	!GlobalTimerNotExpired("BD_BANTER_DELAY","MYAREA") //this means "timer IS expired"
+THEN
+	RESPONSE #100
+		SetAreaScript("",GENERAL) //sets area script back (default is "no GENERAL script")
+END
+	</pre>
+	  <p>And the according compilation of the banter "area" files in the tp2:</p>
+	 <pre class="code">  
+/* banter scripts with Corwin */
+COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/baf/xxBiff01.baf~
+COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/baf/xxBiff02.baf~
+	</pre>
 	
       <h2><a name="toc_3">3. Having another NPC Interject into the Banter</a></h2>
 	  <p>What if we want to have another NPC participate in the banter, but without making the whole banter dependent on this other NPC's presence? If they are there and can talk, they should pipe in, but if not, the banter between Corwin and Biff should fire nontheless.</p>
-	  <p>For this, we include the other NPC's line into our banter "area" script, together with another script block that toggles the switch variable. Let's say Minsc should say something after Biff's first line if he's there. If not, the banter should skip his line and just Corwin and Biff should banter with each other.</p>
-	  <p>For Biff's first line, the variable is either at "0" (if we chose one banter per file and did not set the variable in Biff's script), or at "1" if it was set in Biff's script. Corwin's line then follows for "10". Minsc's line should be between the two, so we set the variable to "2", i.e. a value between the two others.</p>
+	  <p>For this, we include the other NPC's line into our banter "area" script, together with another script block that toggles the switch variable. Let's say Minsc should say something after Biff's first line if he's there. If not, the banter should skip his line and just Corwin and Biff should banter with each other like they would in the example of section 2.</p>
+	  <p>For Biff's first line, the variable is at "0" (if we chose one banter per file and did not set the variable in Biff's script, or it is at "1" if it was set in Biff's script). Corwin's line then follows for "10". Minsc's line should be between the two, so we set the variable to "2", i.e. a value between the two others.</p>
 	  <p>In this case, the xxBiff01.baf would look like this:</p>
 	 <pre class="code">  
-/*  banter "area" script "xxBiff01.baf" with Biff-Corwin banter including Minsc's interjection: */
+/*  banter "area" script "xxBiff01.baf" with 1st Biff-Corwin banter including Minsc's interjection: */
 
 /* this script block toggles Minsc's line: if he is there an can talk, his line will come before Corwin's. */
 IF
-	Global("xx_SoD_xxBiff01","MYAREA",10) //"10" means Corwin's line would be next
-	Global("xx_SoD_xxBiff01_2","MYAREA",0)
+	Global("xxBiff_SoD_xxBiff01","MYAREA",10) //"10" means Corwin's line would be next
+	Global("xxBiff_SoD_xxBiff01_2","MYAREA",0) //make sure this script block only runs once when it should
 	IfValidForPartyDialogue("MINSC")  // Minsc is present and can talk
 THEN
 	RESPONSE #100
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",2) //variable is set to "2" so now Minsc can say his line
-		SetGlobal("xx_SoD_xxBiff01_2","MYAREA",1)
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",2) //variable is set to "2" so now Minsc can say his line
+		SetGlobal("xxBiff_SoD_xxBiff01_2","MYAREA",1) //close variable of this script block so it only runs once
 END
 
 IF
 	InMyArea(Player1)
 	!ActuallyInCombat()
 	!GlobalTimerNotExpired("BD_BANTER_DELAY","MYAREA") //this means "timer IS expired" or "was never set yet"
-	!Global("xx_SoD_xxBiff01","MYAREA",-1) //This is how SoD does it, with one banter per file. If you want to put all banters into one file, use "GlobalGT("xx_SoD_xxBiff01","MYAREA",0)" instead, so only this banter can fire.
-	Switch("xx_SoD_xxBiff01","MYAREA") //this switches between the different RESPONSE #x depending on the variable's value ("x").
+	!Global("xxBiff_SoD_xxBiff01","MYAREA",-1) //stop the loop if the variable is at "-1"
+	Switch("xxBiff_SoD_xxBiff01","MYAREA") //this switches between the different RESPONSE #x depending on the variable's value ("x").
 THEN
-	RESPONSE #0 //This is how SoD does it, with one banter per file. 
-	//use "RESPONSE #1" instead if you want to put all banters into one file and set the Global("xx_SoD_xxBiff01","MYAREA",1) to "1" in Biff's script (because then the variable is already at 1 when the script is called.)
+	RESPONSE #0 
 		DisplayStringHead("xxBiff",~I'm not sure what I should be talking about. I know all the other NPC's lines, though! Pretend I'm Minsc, yes?~)  
-		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",9) 
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",10) 
+		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",9) //The value given here is the time in seconds until the next NPC line is shown. Chose the value depending on the length of the sentence / audio file.
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",10) 
 	RESPONSE #2 //This is Minsc's line
 		DisplayStringHead("MINSC",~Ah, but Biff will never be a real Minsc, without a giant space hamster!~)  
 		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",7) 
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",10) //now the variable is reset to "10" and Corwin's line will fire next.
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",10) //This makes the "switch" jump to the "RESPONSE #10" for the next loop: the script is still active, the script block gets executed again, but this time, Corwin replies:
 	RESPONSE #10
-		DisplayStringHead("CORWIN",58849)  // There's no shortfall of faces deserving a good kick in this world. I'm sure we'll come across one sooner than later.
+		DisplayStringHead("CORWIN",%2%58849)  // ~There's no shortfall of faces deserving a good kick in this world. I'm sure we'll come across one sooner than later.~ - We use existing lines from here, the string numbers have to be ajusted for EET. //the "%2%" is for unifying string reference numbers for SoD and EET. Definition and use please refer to Modding Tutorial Part 3, Chapter "Training the Recruits in the Coalition Camp".
 		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",8)
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",20)
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",20)
 	RESPONSE #20
-		DisplayStringHead("xxBiff",58850)  // And then Minsc does what he does best! Hehe!
+		DisplayStringHead("xxBiff",%2%58850)  // ~And then Minsc does what he does best! Hehe!~ 
 		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",4)
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",30)
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",30)
 	RESPONSE #30
-		DisplayStringHead("corwin",58851)  // Ramble nonsensically to his pet rodent about other peoples' rears?
-		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",ONE_MINUTE) 
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",40)
+		DisplayStringHead("corwin",%2%58851)  // ~Ramble nonsensically to his pet rodent about other peoples' rears?~
+		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",ONE_MINUTE) //With ONE_MINUTE = 6
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",40)
 	RESPONSE #40
-		DisplayStringHead("xxBiff",58852)  // And then Minsc will do what he does second best!
+		DisplayStringHead("xxBiff",%2%58852)  // ~And then Minsc will do what he does second best!~
 		SetGlobalTimer("BD_BANTER_DELAY","MYAREA",4)
-		SetGlobal("xx_SoD_xxBiff01","MYAREA",-1) 
+		SetGlobal("xxBiff_SoD_CorwinBanter","GLOBAL",3) // close variable after 1st banter
+		SetGlobal("xxBiff_SoD_xxBiff01","MYAREA",-1) //this defines the banter to end, and the wanted "loop" cycle stops. The script is still active, so the second script blocks gets executed:
 END
 
 /* second script block: deactivate this script by resetting the area script. This script block is needed once at the end of the banter "area" file. */
@@ -320,11 +417,190 @@ IF
 	!GlobalTimerNotExpired("BD_BANTER_DELAY","MYAREA") 
 THEN
 	RESPONSE #100
-		SetAreaScript("",GENERAL) 
+		SetAreaScript("",GENERAL) //sets area script back (default is "no GENERAL script")
+END
+
+/* second script block: deactivate this script by resetting the area script. This script block is needed once at the end of the banter "area" file. */
+IF
+	!GlobalTimerNotExpired("BD_BANTER_DELAY","MYAREA") 
+THEN
+	RESPONSE #100
+		SetAreaScript("",GENERAL) //sets area script back (default is "no GENERAL script")
 END
 	</pre>
+
+
+      <h2><a name="toc_4">4. Include Optional Component for Banters in "Dialog Style"</a></h2>
+      <p>This section shows how you can transfer the "SoD style banters" into "dialogue style" banters, with banters not happening as text lines above the NPC's heads while they walk around but inside a dialogue box like they are in BG2 and most mods. The syntax for the tp2 conversion from script call to NPC interaction was taken from the mod <a href="https://forums.beamdog.com/discussion/66674/sod-dialogue-banters">SoD Dialogue Banters, by AstroBryGuy</a> which gives this conversion for the original NPCs.</p>
+	  <p>For this, we first need to prepare the game to be able to play banters with the NPCs' banter files defined in bdbanter.2da. The engine supports it in SoD, but because of the different way of scripting banters in SoD, the bdbanter.2da does not exist in the original game. Also, the original game does not include the actual banter files for the original NPCs. We will need to add all files first if they are not already present from another mod. See also <a href="https://www.gibberlings3.net/forums/topic/34950-how-to-assigning-banter-files-for-original-npcs-to-bdbanter2da-in-sod-community-effort/">[How-To] Assigning Banter Files for Original NPCs to bdbanter.2da in SoD (Community Effort)</a>.</p>
+	  <p class="info">Please note: in BG:SoD, Imoen's scriptname is IMOEN, whereas in EET you'll see that it is IMOEN2. Since EET ships with bdbanter.2da present, we only need to consider SoD. We can use the same code to patch it for EET because we check for the existence of all files anyhow just in case another mod already put them in.</p>
+      <p>This is the contents of <strong>bdbanter.2da</strong> we put into an own file:</p>
+	 <pre class="code">  
+2DA      V1.0
+NONE
+         FILE
+KIVAN    BDKIVANB
+ALORA    BDALORAB
+MINSC    BDMINSCB
+DYNAHEIR BDDYNAHB
+YESLICK  BDYESLIB
+CORAN    BDCORANB
+AJANTIS  BDAJANTB
+KHALID   BDKHALIB
+JAHEIRA  BDJAHEIB
+GARRICK  BDGARRIB
+SAFANA   BDSAFANB
+FALDORN  BDFALDOB
+BRANWEN  BDBRANWB
+QUAYLE   BDQUAYLB
+XAN      BDXANB
+SKIE     BDSKIEB
+ELDOTH   BDELDOTB
+XZAR     BDXZARB
+MONTARON BDMONTAB
+TIAX     BDTIAXB
+KAGAIN   BDKAGAIB
+SHARTEEL BDSHARTB
+EDWIN    BDEDWINB
+VICONIA  BDVICONB
+IMOEN    BDIMOENB
+NEERA    BDNEERAB
+DORN     BDDORNB
+RASAAD   BDRASAAB
+BAELOTH  BDBAELOB
+VOGHILN  BDVOGHIB
+MKHIIN   BDMKHIIB
+CORWIN   BDCORWIB
+GLINT    BDGLINTB
+	</pre>
+      <p>To first create - if not already present - and also patch the bdbanter.2da, this is what you need to add to the<strong>tp2</strong>, with "xxBiff" being the example NPC's scriptname you would replace with your NPC's scriptname.</p>
+	 <pre class="code">  
+/* SoD bdbanter.2da - create if not present and patch with Biff's entry */
+ACTION_IF !(FILE_EXISTS_IN_GAME ~BDBANTER.2DA~) BEGIN
+  COPY ~%MOD_FOLDER%/2da/BDBANTER.2DA~ ~override~ 
+END
+ACTION_IF (FILE_EXISTS_IN_GAME ~BDBANTER.2DA~) BEGIN
+  APPEND ~bdbanter.2da~
+		~xxBiff 	xxBiffB~ //replace with scriptname and banter file name of your NPC
+  UNLESS ~xxBiff~ //replace with scriptname of your NPC      
+END
+	</pre>
+	  <p>Next problem is that the banter.dlgs of the NPCs are not existent in the original SoD game, as already pointed out. They need to be present if we want to add to them, so we make sure they are created, but only if they were not present already. Again, this can be used for EET without adaption.</p>
+      <p>To create the banter.dlgs if they are not present yet, this goes into the <strong>tp2</strong> of your NPC mod. This syntax considers all banter.dlgs for all original NPCs:</p>
+	 <pre class="code">  
+/* Create NPC's Banter file if not present */
+COPY ~%MOD_FOLDER%/2da/BDBANTER.2DA~ ~%MOD_FOLDER%/install~
+	COUNT_2DA_COLS cols
+	COUNT_2DA_ROWS cols rows
+	FOR ( row = 2 ; row < rows ; row = row + 1 ) BEGIN
+		READ_2DA_ENTRY %row% 0 2 npc_dv
+    	READ_2DA_ENTRY %row% 1 2 banterfile
+      	INNER_ACTION BEGIN
+		ACTION_IF NOT FILE_EXISTS_IN_GAME ~%banterfile%.dlg~ THEN BEGIN
+		<<<<<<<< .../banterfiles-inlined/%banterfile%.d
+		 BEGIN %banterfile%
+		>>>>>>>>
+		COMPILE EVALUATE_BUFFER ~.../banterfiles-inlined/%banterfile%.d~ 
+		END
+      	END
+	END
+BUT_ONLY
+	</pre>
+	  <p>For the actual banters, we do need an extra d-file containing all banters with the lines from the banter "area" baf-files. All banters with all NPCs can go into the same d-file.</p>
+	  <p class="info">Please note: This banter d-file and the banter "area" script files will use the same text lines. Make sure you use the same tra-file for both d-file and baf-files containing the banters when you "traify" the mod so lines will not be doubled.</p>
+	  <p>For Biff's banters, the file will be called <strong>xxbiff_banter_sod.d</strong> and has the following content:</p>
+	 <pre class="code">  
+/* (T4) this is xxbiff_banter_sod.d: Biff's banters in "dialogue style" format, for the optional component to transform his banters. Triggered by his OVERRIDE script. */
+
+/* 1st with Corwin, "xxBiff01.baf". Minsc interjects if he's present */
+CHAIN
+IF WEIGHT #-1
+/* We only need the checking variable here. All other checks (whether NPCs can talk etc. was done inside the script. */
+~Global("xxBiff_SoD_CorwinBanter","GLOBAL",2)~ THEN xxBiffB biff_corwin_sod_1
+~I'm not sure what I should be talking about. I know all the other NPC's lines, though! Pretend I'm Minsc, yes?~
+DO ~SetGlobal("xxBiff_SoD_CorwinBanter","GLOBAL",3)~ //we need to close the variable for dialogue style, too.
+/* Minsc's line - will only show if he's present and can talk. */
+== BDMINSCB IF ~IfValidForPartyDialogue("MINSC")~ THEN ~Ah, but Biff will never be a real Minsc, without a giant space hamster!~
+/* the "%2%" is for unifying string reference numbers for SoD and EET. Definition and use please refer to Modding Tutorial Part 3, Chapter "Training the Recruits in the Coalition Camp". */
+== BDCORWIB #%2%58849 
+== xxBiffB #%2%58850
+== BDCORWIB #%2%58851
+== xxBiffB #%2%58852
+EXIT
+
+/* 2nd with Corwin, "xxBiff02.baf" - started by Corwin */
+CHAIN
+IF WEIGHT #-1
+/* We only need the checking variable here. All other checks (whether NPCs can talk etc. was done inside the script. */
+~Global("xxBiff_SoD_CorwinBanter","GLOBAL",5)~ THEN BDCORWIB biff_corwin_sod_2
+~So, what does it feel like, being a real NPC and not only the Understudy?~
+DO ~SetGlobal("xxBiff_SoD_CorwinBanter","GLOBAL",6)~ //we need to close the variable for dialogue style, too.
+== xxBiffB ~Wait, I don't know that line... Oh, it's a real question! Thank you! Thank you, Corwin! I feel great!~
+EXIT
+	</pre>
+	  <p>Now we need to adapt the triggering of the banters. Currently, an area script is set. We need to change this to "Interact()" between the two NPCs talking. To make the transformation as simple as possible, we will use a 2da file which will give details about the banter area file name, the NPC script triggering the banter, and the scriptname of the NPC spoken to for every banter.</p>	
+	 <p>The rows and columns in the xxbiffbx.2da mean the following:</p> 
+	  <ol>
+        <li>Each row is for one banter. The first column gives the "area" script file name of the relevant banter.</li>
+        <li>The second column gives the OVERRIDE scripts the banter will be started from.</li>
+        <li>The third column gives the scriptname (death variable) of the NPC <strong>spoken to</strong> (i.e. not the NPC starting the banter, but the one that should be the conversion partner being addressed in the banter).</li>
+	  </ol>
+	  <p>For the two banters with Corwin, the 2da would look like this. We call it <strong>xxbiffbx.2da</strong>:</p>
+	 <pre class="code">  
+/* banter area file name - OVERRIDE script - scriptname of conversion partner */
+xxBiff01	xxBiffs		CORWIN
+xxBiff02	bdcorwin	xxBiff
+	</pre>
+	  <p>This is the code you need in the tp2 to let weidu make the transformation upon install: all "SetAreaScript"s are now transformed into "Interact()" actions, and because of the 2da the installer knows which banter should be triggered by which script block because each banter has a unique file name. (This is why we put every banter into a single file.)</p>
+	 <pre class="code">  
+/* change the calling of the scripts to "Interact("npc") for all banters 
+Code taken from AstroBryGuy's "SoD Dialog Banters" mod with many thanks! */
+// Edit NPC scripts to start Interact actions for banters
+COPY ~%MOD_FOLDER%/2da/xxBiffbx.2da~ ~c#brandock/install~
+	COUNT_2DA_COLS cols
+	COUNT_2DA_ROWS cols rows
+	FOR ( row = 0 ; row < rows ; row = row + 1 ) BEGIN
+		READ_2DA_ENTRY %row% 0 3 banter
+    	READ_2DA_ENTRY %row% 1 3 script
+    	READ_2DA_ENTRY %row% 2 3 interact
+      	INNER_ACTION BEGIN
+      		COPY_EXISTING ~%script%.BCS~ ~override~
+    			DECOMPILE_AND_PATCH BEGIN
+        			REPLACE_TEXTUALLY ~SetAreaScript("%banter%",GENERAL)~ ~Interact("%interact%")~
+        		END
+        	BUT_ONLY
+      	END
+	END
+BUT_ONLY
+	</pre>
+      <p>Now we only need to wrap this into an optional component which is dependent on the main mod, and we are done - all players happy!</p> 
+      <p>The following covers the structure for the optional component and goes into the <strong>tp2</strong>. To complete it, fill in the above given tp2 content:</p>
+	<pre class="code">	  
+///////////////////////////////////////////////////////////
+// Use Dialogue Style for SoD Banters //
+/////////////////////////////////////////////////////////
+
+
+BEGIN ~Use Dialogue Style for SoD Banters for Biff~ 
+DESIGNATED 10 /* giving the component a DESIGNATED number which will not change in the future is of great importance for crossmod compatibility. In this case, "10" is an arbitrary number greater than "0" which is the main component. Chose the number so it makes sense in your mod. */
+LABEL xxbiff_sod_tutorial_mod-dialogue_style_sod_banter /* define a unique global label for this mod component(!). It basically does what DESIGNATED does, only better. And it helps Project Infinity remember the component when setting up an install list. */
+/* make sure the component can only be installed if the main component is installed */
+REQUIRE_COMPONENT ~xxBiff.tp2~ ~0~  ~Biff main component needs to be installed for this.~
+/* in case your main mod also covers other games than SoD, we include the SoD check again because this component only makes sense for SoD: */
+REQUIRE_PREDICATE (GAME_IS ~bgee eet~ AND FILE_EXISTS_IN_GAME ~bd0103.are~) @90001 /* ~This mod is really only for SoD~ */
+
+//add creation of bdbanter.2da here (s. above) - it could also go into the main mod.
+
+//add creation of banter files for original NPCs here (s. above)
+
+COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/dialogue/xxbiff_banter_sod.d~
+
+//add conversion from "SetAreaScript" to "Interact" here (s. above)
+
+	</pre>
+	
 	  
-      <h2><a name="toc_4">4. Credits, Used Tools, and Helpful Links</a></h2>
+      <h2><a name="toc_100">5. Credits, Used Tools, and Helpful Links</a></h2>
 	  <p>Thank you to Argent77 for the html template!</p>
 	  <p>Used Tools:</p>
       <p><a href="https://github.com/Argent77/NearInfinity/releases/latest">Near Infinity</a></p>
@@ -337,9 +613,18 @@ END
       <p><a href="http://www.spellholdstudios.net/">Spellhold Studios</a></p>
       <p><a href="http://www.pocketplane.net/mambo/">Pocket PLane Group</a></p>
       <p><a href="http://forums.blackwyrmlair.net/index.php?showtopic=113">Prefix Reservation at Black Wyrm Lair Forums</a></p>
+	  <p><a href="https://forums.beamdog.com/discussion/66674/sod-dialogue-banters">Mod: SoD Dialogue Banters, by AstroBryGuy</a></p>
+	  <p><a href=
+	  <p><a href="https://forums.pocketplane.net/index.php?topic=23822.0">"Tutorial: How to ensure your banters always run when you want them to"</a></p>
+	  <p><a href="https://www.gibberlings3.net/forums/topic/34950-how-to-assigning-banter-files-for-original-npcs-to-bdbanter2da-in-sod-community-effort/">[How-To] Assigning Banter Files for Original NPCs to bdbanter.2da in SoD (Community Effort)</a>.</p>
 	  
 	  
-      <h2><a name="toc_5">5. Version History</a></h2>
+      <h2><a name="toc_101">6. Version History</a></h2>
+          <p>Version 3:</p>
+          <ul>
+            <li>Added new chapter: Include Optional Component for Banters in "Dialog Style"</li>
+            <li>Examples in chapters 1-3 adjusted for compatibility with new chapter 4. (i.e. used variables changed; comments on how to put all banters into one single baf file removed.)</li>
+          </ul>
           <p>Version 2:</p>
           <ul>
             <li>moved sidenote about detecting SoD into tutorial no. 1 "Automatic Transition of NPCs into SoD and between Camps in SoD"</li>

--- a/docs/Tutorial_SoDBanterSystem.html
+++ b/docs/Tutorial_SoDBanterSystem.html
@@ -512,6 +512,8 @@ BUT_ONLY
 	 <pre class="code">  
 /* (T4) this is xxbiff_banter_sod.d: Biff's banters in "dialogue style" format, for the optional component to transform his banters. Triggered by his OVERRIDE script. */
 
+BEGIN xxBiffB //dlg needs to be created once
+
 /* 1st with Corwin, "xxBiff01.baf". Minsc interjects if he's present */
 CHAIN
 IF WEIGHT #-1
@@ -547,7 +549,6 @@ EXIT
 	  </ol>
 	  <p>For the two banters with Corwin, the 2da would look like this. We call it <strong>xxbiffbx.2da</strong>:</p>
 	 <pre class="code">  
-/* banter area file name - OVERRIDE script - scriptname of conversion partner */
 xxBiff01	xxBiffs		CORWIN
 xxBiff02	bdcorwin	xxBiff
 	</pre>
@@ -622,8 +623,9 @@ COMPILE EVALUATE_BUFFER ~%MOD_FOLDER%/dialogue/xxbiff_banter_sod.d~
       <h2><a name="toc_101">6. Version History</a></h2>
           <p>Version 3:</p>
           <ul>
-            <li>Added new chapter: Include Optional Component for Banters in "Dialog Style"</li>
-            <li>Examples in chapters 1-3 adjusted for compatibility with new chapter 4. (i.e. used variables changed; comments on how to put all banters into one single baf file removed.)</li>
+            <li>Tutorial was revised and updated with new content. This includes unification of used naming schemes, correction of typos and oversights. Proposed examples might have changed in details.</li>
+            <li>Added new chapter: Include Optional Component for Banters in "Dialog Style". Examples in chapters 1-3 adjusted for compatibility with new chapter 4. (i.e. used variables changed; comments on how to put all banters into one single baf file removed.)</li>
+            <li>Examples in chapters 1 and 3 expanded: Biff and Corwin banter two times now.</li>
           </ul>
           <p>Version 2:</p>
           <ul>

--- a/docs/Tutorial_SoDGeneralNPCThings.html
+++ b/docs/Tutorial_SoDGeneralNPCThings.html
@@ -418,7 +418,7 @@ EXTEND_TOP ~bd0120.bcs~ ~%MOD_FOLDER%/baf/bd0120_commenting_et.baf~
 	<h2><a name="toc_4">4. Comment in the morning after the last night in the Ducal Palace (before heading out against the Crusade)</a></h2>
     <p>This is for NPCs the player takes into the group before leaving for the crusade. In the game, all original NPCs recruitable in BG city, i.e. Minsc, Dynaheir, and Safana, have a comment in the morning after the last night in the Ducal Palace, after Skie woke up the PC. For this, those three NPCs are moved into the PC's bed chamber by bdcut05.bcs which is triggered by Skie's dialgogue bdskie.dlg. Multiplayer NPCs (or mod NPCs without an addition) will be standing in the hall between the PC's and Imoen's chambers.</p> 
 	<p>The actual moving of the party NPCs is done by bdcut05.bcs, but it is scripted in a way that patching it neither at top nor bottom will move mod NPCs in time. If we want Biff to be in the room, too, we need to patch the JumpToPoint to his OVERRIDE script. His morning comment needs to be patched to <strong>bd0103.bcs</strong> via EXTEND_TOP.</p>
-	  <p class="info">This is only needed for your NPC if they are already available inside Baldur's Gate city.</p> 
+	  <p class="info">This is only needed for your NPC if they are already available inside the Baldur's Gate city areas of SoD.</p> 
 	<p>The following goes into Biff's OVERRIDE script xxBiffs.baf:</p>
 	<pre class="code">	
 /* Move Biff to the table in the morning after the last night in the Ducal Palace (before heading out against the Crusade) */
@@ -490,7 +490,7 @@ THEN
 	RESPONSE #10
 		SetGlobalTimer("bd_mdd010z_ot_timer","bd0101",ONE_ROUND)
 		SetGlobal("bd_mdd010z_ot","bd0101",0)
-		DisplayStringHead("xxBiff",~Wait... do I have all the scripts? (murmurs) Corwin, Dunkan, Glint... Yes, all here. (phew)~
+		DisplayStringHead("xxBiff",~Wait... do I have all the scripts? (murmurs) Corwin, Dunkan, Glint... Yes, all here. (phew)~)
 		Continue()
 END
 	</pre>
@@ -581,8 +581,7 @@ EXTEND_BOTTOM ~bd1000.bcs~ ~%MOD_FOLDER%/baf/bd1000_commenting.baf~
         <li>Biff will have a comment as floating text in case the spike trap is activated to kill the crusaders.</li>
 	  </ol>	  
 	  <p>The comment into the dialogue is a simple I_C_T that needs to be put into a .d-file. In the tutorial mod package it is called <strong>sod_event_comments.d</strong>:<p>	  
-	 <pre class="code"> 
-/* put this into sod_event_comments.d */	 
+	 <pre class="code"> 	 
 /* PC threatens to kill the crusaders with the spikes in bd7230.are */
 I_C_T bdkharmy 6 xxBiff_bdkharmy_6
 == xxBiffJ IF ~IsValidForPartyDialogue("xxBiff")~ THEN ~Wow, eeeevil.~
@@ -928,7 +927,7 @@ END
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
 /* Comment before entering the Cave with the blind Wyrmlings (bd5100aw.bcs) */
-EXTEND_BOTTOM ~bd5100aw.bcs~ ~%MOD_FOLDER%/baf/xxbd5100aw_commenting.baf.baf~
+EXTEND_BOTTOM ~bd5100aw.bcs~ ~%MOD_FOLDER%/baf/xxbd5100aw_commenting.baf~
 EVALUATE_BUFFER
 	</pre>	
 	  <p>The comment is an actual dialogue pop up. The following goes into the NPC's joined dialogue file:</p>
@@ -1085,14 +1084,14 @@ END
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
 /* Comment in Dragonspear Castle Exterior */
-EXTEND_BOTTOM ~bdbark01.bcs~ ~%MOD_FOLDER%/baf/xxbdbark01_commenting.baf.baf~
+EXTEND_BOTTOM ~bdbark01.bcs~ ~%MOD_FOLDER%/baf/xxbdbark01_commenting.baf~
 EVALUATE_BUFFER
 	</pre>
 		
 		
       <h2><a name="toc_19">22. Move the PC in the cutscene of the plotting nobles in Three Old Kegs (bdc116d.bcs)</a></h2>
 	  <p>When the PC interacts with the plotting nobles in the Three Kegs there is a cutscene which gets called twice which places the party NPCs inside the northwest room where the confrontation with the Flaming Fist takes place. Unfortunately, instead of just using the general Player2-6 the script works with the explicit NPC names that are available until then - Safana, Minsc, and Dynahier. We need to add our NPC explicitely, too.</p>
-	  <p class="info">This is only needed for your NPC if they are already available inside Baldur's Gate city.</p> 
+	  <p class="info">This is only needed for your NPC if they are already available inside the Baldur's Gate city areas of SoD.</p> 
 	  <p>This is what we will patch to <strong>bdc116d.bcs</strong>:</p>
 	 <pre class="code">  
 /* xxbdc116d.baf */
@@ -1354,13 +1353,13 @@ IF ~~ THEN DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",11)~ EXIT // We need to do t
 
 /* Clovis */
 EXTEND_BOTTOM BDCLOVIS 3
-+ ~IfValidForPartyDialogue("xxBiff")~ + ~[PC reply]Biff, any advice?~ */ EXTERN xxBiffJ teach_clovis
++ ~IfValidForPartyDialogue("xxBiff")~ + ~[PC reply]Biff, any advice?~ EXTERN xxBiffJ teach_clovis
 END
 
 CHAIN
 IF ~~ THEN xxBiffJ teach_clovis
 ~I see a mistake smaller men do when trained by taller ones. Fighting wears your arms out quite a bit, doesn't it?~
-== #%2%48085 /* ~I do tire pretty quickly during drills. I thought I just needed more training.~ */
+== BDCLOVIS #%2%48085 /* ~I do tire pretty quickly during drills. I thought I just needed more training.~ */
 == xxBiffJ ~Focus on weak spots were you do not have to reach upwards. There are more than you might think. The foes will fear you for it - and you will wear out less quickly.~
 END
 IF ~~ THEN DO ~IncrementGlobal("BD_FIGHTERS_SKILL","BD3000",2)
@@ -1368,7 +1367,7 @@ SetGlobal("bd_sdd301_clovista_skill","global",2)~ EXTERN BDCLOVIS 5
 
 /* Danine */
 EXTEND_BOTTOM BDDANINE 3
-+ ~IfValidForPartyDialogue("xxBiff")~ + ~Biff, you think you can teach this recruit to improve her skills?~ EXTERN xxBiffsj teach_danine
++ ~IfValidForPartyDialogue("xxBiff")~ + ~Biff, you think you can teach this recruit to improve her skills?~ EXTERN xxBiffJ teach_danine
 END
 
 /* there will be a short fighting scene, then Biff talks again */
@@ -1587,10 +1586,12 @@ END
       <h2><a name="toc_101">31. Version History</a></h2>
           <p>Version 3:</p>
           <ul>
+            <li>Tutorial was revised and updated with new content. This includes unification of used naming schemes, correction of typos and oversights. Proposed examples might have changed in details.</li>
             <li>New chapter: Training the Recruits in the Coalition Camp</li>
             <li>New chapter: The Chicken, the Well, and the Dog Easter Egg</li>
             <li>New chapter: Providing the "Skipit" Functionality for Cutscenes</li>
             <li>New chapter: Promotion of the Road to Discovery Mod and its Possibilities for your NPC Mod</li>
+            <li>Unified Biff's joined.dlg to "xxBiffJ".</li>
             <li>Chapter paragraphs are numbered now.</li>
             <li>Chapters about commenting in final scene deprecated ("Last area bd6100.are: comment in abduction scene (EET)").</li>
           </ul>	  

--- a/docs/Tutorial_SoDGeneralNPCThings.html
+++ b/docs/Tutorial_SoDGeneralNPCThings.html
@@ -110,15 +110,15 @@
     <div id="wrap"> <!-- Start content wrapper -->
       <h1>Modding Tutorial Part 3: Add Other General SoD Behavior to Your NPC: XP Adjustment, Actions in Story Cutscenes, Commenting of Main Story Events</h1>
 	  
-	<p>Version 2, by jastey. Note: This is a work in progress.</p>
+	<p>Version 3, by jastey.</p>
 
       <div id="toc">
         <h2><a name="toc">Contents</a></h2>
         <ol class="toc">
           <li><a href="#toc_1">Some general script additions</a></li>
-		  <li><a href="#toc_2">Biff comments on his further plans in Korlasz's Crypt</a></li>
-          <li><a href="#toc_3">Comment on defeating the first Enemies in Korlasz's Crypt</a></li>
-          <li><a href="#toc_4">Comment in the morning after the last night in the Ducal Palace</a></li>
+		  <li><a href="#toc_2">Biff comments on his further plans in Korlasz' Crypt</a></li>
+          <li><a href="#toc_3">Comment on defeating the first Enemies in Korlasz' Crypt</a></li>
+          <li><a href="#toc_4">Comment in the morning after the last night in the Ducal Palace (before heading against the Crusade)</a></li>
           <li><a href="#toc_5">Biff should comment on the coalition being ready to leave BG city</a></li>
           <li><a href="#toc_6">Biff should move when the coalition starts marching out of BG city</a></li>
           <li><a href="#toc_brexp">Reaction to the destroyed Bridge at Coastway Crossing</a></li>
@@ -131,23 +131,27 @@
           <li><a href="#toc_11">Comments in bd4300.are (Bridgefort Castle interior and Avernus portal)</a></li>
           <li><a href="#toc_12">Comment upon entering Avernus</a></li>
           <li><a href="#toc_13">Comment in the Avernus Elevator</a></li>
-          <li><a href="#toc_14">Comment before entering the Cave with the blind Wyrmlings (bd5100aw.bcs)Comment on the blind Wyrmlings in Cave (bd5100aw.bcs and bd0113.bcs)</a></li>
+          <li><a href="#toc_14">Comment before entering the Cave with the blind Wyrmlings (bd5100aw.bcs)</a></li>
           <li><a href="#toc_15">Comment after killing the blind Wyrmlings in Cave (bd0113.bcs)</a></li>
           <li><a href="#toc_16">Comment when battle starts in Kanaglym (bd5300.are, Underground River)</a></li>
-          <li><a href="#toc_17">Last area bd6100.are: comment in abduction scene (EET)</a></li>
+          <li><a href="#toc_17">Last area bd6100.are: comment in abduction scene (EET)[DEPRECATED]</a></li>
           <li><a href="#toc_18">Comment in Dragonspear Castle Exterior</a></li>
 		  <li><a href="#toc_19">Move the PC in the cutscene of the plotting nobles in Three Old Kegs (bdc116d.bcs)</a></li>
 		  <li><a href="#toc_20">Comment on closed vault door (to portal) in Dragonspear Castle Interior</a></li>
 		  <li><a href="#toc_21">Avernus: Thrix' Game</a></li>
+		  <li><a href="#toc_22">Training the Recruits in the Coalition Camp</a></li>
+		  <li><a href="#toc_23">The Chicken, the Well, and the Dog Easter Egg</a></li>
+		  <li><a href="#toc_24">Providing the "Skipit" Functionality for Cutscenes</a></li>
           <li><a href="#toc_12b">Make the Mod EET compatible</a></li>
-		  <li><a href="#toc_22">Placeholder</a></li>
-		  <li><a href="#toc_23">Placeholder</a></li>
+          <li><a href="#toc_50">Promotion of the Road to Discovery Mod and its Possibilities for your NPC Mod</a></li>
           <li><a href="#toc_100">Credits, Used Tools, and Helpful Links</a></li>
           <li><a href="#toc_101">Version History</a></li>
         </ol>
       </div>
 
-      <p class="info">This tutorial deals with giving your NPC some general script additions like XP adjustment upon joining, removing of Story Mode upon leaving the group, and also reacting to the main game events and letting him move in cutscenes if not in party where appropriate.</p>
+      <p class="info">This tutorial deals with giving your NPC some general script additions like XP adjustment upon joining, removing of Story Mode upon leaving the group, letting the NPC move in cutscenes if not in party, and inclusion into general NPC reaction points to the main game events.</p>
+	  <p class="info">The listed situations in this tutorial are the ones where general reactions depending on class, race, or alignment of all or several NPCs in group are included in the game and where a mod NPC should not be missing. It does not give examples of possible interjection points depending on individual NPCs' character or personal reactions to game events etc.</p>
+	  <p class="info">The tutorial now includes all instances I could find by browsing the game files. Let me know if I missed anything or if you have general critique. The tutorial might change after I finished my own NPC mods for SoD.</p>
       <p><strong>Some nomenclature:</strong></p>
       <table>
         <col width="180" />
@@ -157,25 +161,26 @@
           <td>used as a modding prefix in this tutorial. If you don't have a prefix, check the <a href="http://www.blackwyrmlair.net/prefixes/">IE Community Filename Prefix Reservations List</a> and register one at <a href="http://forums.blackwyrmlair.net/index.php?showtopic=113">Black Wyrm Lair Forums</a>.</td>
         </tr>
           <td>xxBiff</td>
-          <td>Biff's script name (death variable)</td>
+          <td>Biff's scriptname (death variable)</td>
         </tr>
         <tr>
           <td>xxBiffs.bcs</td>
           <td>Biff's SoD override script</td>
         </tr>
         <tr>
-          <td>xxBiffsJ.dlg</td>
+          <td>xxBiffJ.dlg</td>
           <td>Biff's joined dialogue</td>
         </tr>
       </table>
-	  <h2><a name="toc_1">Some general script additions</a></h2>
-      <p>This chapter presents script additions every NPC in SoD has in their OVERRIDE script. They are for XP adjustment upon joining in SoD, total healing and dispell of effects after leaving the Ducal Palace, and removing of Story Mode from NPC if leaving the party.</p> 
+	  <h2><a name="toc_1">1. Some general script additions</a></h2>
+      <p>This chapter presents script additions every NPC in SoD has in their OVERRIDE script. They are for XP adjustment upon joining in SoD, total healing and dispell of effects after leaving the Ducal Palace, and removing of Story Mode if leaving the party.</p> 
       <p>The first eight script blocks deal with levelling the NPC up to match the XP the PC has in SoD. This is especially interesting if your NPC was left standing in BG:EE and is supposed to rejoin the group now, or for a new SoD game if they will join later in SoD where the PC had time to level up. It also gives the possibility to use one cre file for both new BG:EE and SoD games without having to think about how to distribute weapon pips etc. (Maybe not as smart for a mage or cleric etc. who need to know higher level spells in SoD, though.)</p> 
-	  <p>The next script block is a full healing and dispelling of any spell effects, deafness, feeblemindedness etc. after Korlasz's crypt is cleared.</p> 
+	  <p>The next script block contains full healing and dispelling of any spell effects, deafness, feeblemindedness etc. after Korlasz' Crypt is cleared.</p> 
 	  <p>The last script block will remove the Story Mode from your NPC if they leave the party.</p> 
-	  <p>You could put these into an own .baf-file and EXTEND_BOTTOM it to your NPC's OVERRIDE script.</p> 
+	  <p>You could put these into an own .baf-file and EXTEND_BOTTOM it to your NPC's SoD OVERRIDE script.</p> 
 	<pre class="code">	 
-/* This file contains no NPC specific variables or names. You can use it to patch it to your NPC's Override script without changes. */
+/* This file contains no NPC specific variables or names. You can use it to patch it to your NPC's SoD Override script without changes. */
+/* in the tutorial mod package, it is called general_script_additions.baf */
 
 
 /* make NPC level up to PC's level upon first joining. You can always reactivate this by resetting SetGlobal("BDSODXP","LOCALS",0). There is a similar thing for the BG:EE part in the according NPC scripts. */
@@ -308,13 +313,23 @@ THEN
 		Continue()
 END
 	</pre>
-      <h2><a name="toc_2">Biff comments on his further plans in Korlasz's Crypt</a></h2>
-      <p>In bd0120.are and also bdo130.are, the two areas of Korlaz's crypt, the NPCs have DisplayStringHeads about what they are planning to do after the dungeon is cleared.</p> 
+	
+     <p>In the tutorial mod package, these scriptblocks are in a file called general_script_additions.baf. The according tp2 patching for adding it to Biff's OVERRIDE script would be:</p>
+	 <pre class="code">  
+/* patching general script additions to Biff's OVERRIDE script */
+EXTEND_BOTTOM ~xxBiffs.bcs~ ~%MOD_FOLDER%/baf/general_script_additions.baf~
+  EVALUATE_BUFFER	
+	</pre>
+	
+	
+      <h2><a name="toc_2">2. Biff comments on his further plans in Korlasz' Crypt</a></h2>
+      <p>In bd0120.are and also bd0130.are, the two areas of Korlaz's crypt, the NPCs have DisplayStringHeads about what they are planning to do after the dungeon is cleared.</p> 
 	  <p>The first script block is before Korlasz is defeated, the NPCs mention that the time together with the PC will come to an end. The second script block is after Korlasz is defeated, the NPCs state their specific plans of leaving and / or congratulate the PC for their victory.</p>
-      <p>For Biff, we patch the following to both <strong>bd0120.bcs</strong> and <strong>bd0130.bcs</strong>:</p>
+	  <p class="info">The script blocks shown here are compatible with EndlessBG1 and Transition Mods where the farewell blurbs will be prevented. Apart from that, please also refer to Tutorial Part 1 Chapter 1 regarding my recommendation how to chose the NPC's joined and banter files in Korlasz' Crypt.</p>
+      <p>For Biff, we patch the following to both <strong>bd0120.bcs</strong> and <strong>bd0130.bcs</strong> so it can play in either area:</p>
 	<pre class="code">	
 /* bd0120_commenting.baf
-In Korlasz's crypt: NPC state their plans after the last follower of Sarevok 2ill be defeated.
+In Korlasz' Crypt: NPC state their plans after the last follower of Sarevok will be defeated.
 This will be patched to both bd0120.bcs and bd0130.bcs. */
 
 /* First comment: before Korlasz will be defeated. */
@@ -362,20 +377,20 @@ END
      <p>And the according tp2 patching:</p>
 	 <pre class="code">  
 /* after Korlasz is defeated: DisplayStringHead of his further plans. 
-Same script blocks get patched to both area scripts of Korlasz's crypt */
+Same script blocks get patched to both area scripts of Korlasz' Crypt */
 EXTEND_BOTTOM ~bd0120.bcs~ ~%MOD_FOLDER%/baf/bd0120_commenting.baf~
   EVALUATE_BUFFER
 EXTEND_BOTTOM ~bd0130.bcs~ ~%MOD_FOLDER%/baf/bd0120_commenting.baf~
   EVALUATE_BUFFER	
 	</pre>
 	
-      <h2><a name="toc_3">Comment on defeating the first Enemies in Korlasz's Crypt</a></h2>
+      <h2><a name="toc_3">3. Comment on defeating the first Enemies in Korlasz' Crypt</a></h2>
       <p>After the first group of enemies in bd0120.are are defeated, up to three NPCs have a DisplayStringHead. Some comment the fight, some the dungeon. Since I like it if the NPCs talk, Biff will comment in addition to the maximum of three other NPCs. Even if some day there will be more mod NPCs no incrementing the variable ("bd_mdd000te_ot"), I didn't see any problems in the game since it's only used to restrict NPC comments to a maximum of three.</p> 
-	   <p class="info">Unless this will be changed in the next game update, these comments and thus also your NPC's will only show for game difficulties harder than EASY and NORMAL, because for these two the number of available opponents do not match the one needed for triggering.</p>
+	  <p class="info">Unless this will be fixed at some point, these comments and thus also your NPC's will only show for game difficulties harder than EASY, because only for these the number of available opponents will match the needed for triggering.</p>
       <p>For Biff, we patch this to <strong>bd0120.bcs</strong> via EXTEND_TOP:</p>
 		<pre class="code">
 /* bd0120_commenting_et.baf
-This is a comment in bd0120.are (Korlasz's crypt) after defeating the first enemies.
+This is a comment in bd0120.are (Korlasz' Crypt) after defeating the first enemies.
 Some NPCs commment on the fight, some on the dungeon.  
 This will be patched to bd0120.bcs via EXTEND_TOP. Originally, only three NPCs will comment. Biff will comment in addition. */
 IF
@@ -390,20 +405,23 @@ THEN
 		SetGlobal("xxBiff_bd_mdd000te_ot","bd0120",1)
 		DisplayStringHead("xxBiff",~I didn't imagine this crypt to be so huge.~)
 		Wait(5)
+		Continue()
 END
 	</pre>
      <p>And the according tp2 patching:</p>
 	 <pre class="code">  
-/* comment after defeating the first enemies in Korlasz's crypt */
+/* comment after defeating the first enemies in Korlasz' Crypt */
 EXTEND_TOP ~bd0120.bcs~ ~%MOD_FOLDER%/baf/bd0120_commenting_et.baf~
   EVALUATE_BUFFER
 	</pre>     
 	
-	<h2><a name="toc_4">Comment in the morning after the last night in the Ducal Palace</a></h2>
+	<h2><a name="toc_4">4. Comment in the morning after the last night in the Ducal Palace (before heading out against the Crusade)</a></h2>
     <p>This is for NPCs the player takes into the group before leaving for the crusade. In the game, all original NPCs recruitable in BG city, i.e. Minsc, Dynaheir, and Safana, have a comment in the morning after the last night in the Ducal Palace, after Skie woke up the PC. For this, those three NPCs are moved into the PC's bed chamber by bdcut05.bcs which is triggered by Skie's dialgogue bdskie.dlg. Multiplayer NPCs (or mod NPCs without an addition) will be standing in the hall between the PC's and Imoen's chambers.</p> 
 	<p>The actual moving of the party NPCs is done by bdcut05.bcs, but it is scripted in a way that patching it neither at top nor bottom will move mod NPCs in time. If we want Biff to be in the room, too, we need to patch the JumpToPoint to his OVERRIDE script. His morning comment needs to be patched to <strong>bd0103.bcs</strong> via EXTEND_TOP.</p>
+	  <p class="info">This is only needed for your NPC if they are already available inside Baldur's Gate city.</p> 
 	<p>The following goes into Biff's OVERRIDE script xxBiffs.baf:</p>
 	<pre class="code">	
+/* Move Biff to the table in the morning after the last night in the Ducal Palace (before heading out against the Crusade) */
 IF
 	Global("bd_plot","global",55)
 	Global("xxBiff_bd_55","bd0103",0)
@@ -417,9 +435,9 @@ THEN
 		SetGlobal("xxBiff_bd_55","bd0103",1)
 END	
 	</pre>
-	<p>The following goes into a .baf file, we will call it bd0103_commenting.baf:</p>
+	<p>The following goes into a .baf file, we will call it bd0103_commenting_et.baf:</p>
 	<pre class="code">	
-/* bd0103_commenting.baf
+/* bd0103_commenting_et.baf
 after Skie woke the PC up on the day of departure */
 IF
 	Global("bd_plot","global",55)
@@ -440,18 +458,18 @@ END
 	</pre>
      <p>And the according tp2 patching:</p>
 	 <pre class="code">  
-/* (T3) in case Biff is in party the last night the PC slept in Ducal Palace - comment after Skie is gone */
-EXTEND_TOP ~bd0103.bcs~   ~%MOD_FOLDER%/baf/bd0103_commenting.baf~  
+/* In case Biff is in party the last night the PC slept in Ducal Palace - comment after Skie is gone */
+EXTEND_TOP ~bd0103.bcs~   ~%MOD_FOLDER%/baf/bd0103_commenting_et.baf~  
   EVALUATE_BUFFER
 	</pre>
 	
 	
-      <h2><a name="toc_5">Biff should comment on the coalition being ready to leave BG city</a></h2>
-      <p>When the PC leaves the Ducal Palace, ready to march against the crusade, all NPCs and relevant coalition leaders (from BG) are gathered in front of the Entrance, along with a cheerful crowd.</p> 
-      <p>The NPCs not in the group have random DisplaystringHeads while they are waiting for the PC either to talk to them or to talk to Corwin and start the march. We give Biff the Understudy, our example NPC, the following lines which need to be patched to <strong>bd0101.bcs</strong> with EXTEND_TOP. Note: we already used the name "xxbd0101.baf" for Biff's spawning as described in tutorial 1, so we will name this file "bd0101_commenting.baf".</p>
-	  <p class="info">Of course, you could put all script blocks for bd0101.bcs into one file and patch them via EXTEND_TOP. But: if you do that, each script block from tutorial 1 needs to have <strong>Continue()</strong> at the end.</p>	  
+      <h2><a name="toc_5">5. Biff should comment on the coalition being ready to leave BG city</a></h2>
+      <p>When the PC leaves the Ducal Palace, ready to march against the crusade, all NPCs and relevant coalition leaders (from BG) are gathered in front of the Entrance, along with a cheerful crowd. The area is now bd0101.are.</p> 
+      <p>The NPCs not in the group have random DisplaystringHeads while they are waiting for the PC either to talk to them or to Corwin and start the march. We give Biff the Understudy, our example NPC, the following lines which need to be patched to <strong>bd0101.bcs</strong> with EXTEND_TOP. Note: we already used the name "xxbd0101.baf" for Biff's spawning as described in Tutorial Part 1, so we will name this file "bd0101_commenting_et.baf", with "_et" for "EXTEND_TOP".</p>
+	  <p class="info">Of course, you could put all script blocks for bd0101.bcs into one file and patch them via EXTEND_TOP. But: if you do that, each script block from Tutorial Part 1 needs to have <strong>Continue()</strong> at the end.</p>	  
 	<pre class="code">	  
-/* bd0101_commenting.baf; this goes into bd0101.bcs */
+/* bd0101_commenting_et.baf; this goes into bd0101.bcs */
 /* Waiting to march out of BG city: make Biff comment while waiting to leave */
 IF
 	Global("bd_mdd010z_ot","bd0101",1)
@@ -479,11 +497,11 @@ END
      <p>And the according tp2 patching:</p>
 	 <pre class="code">  
 /* Waiting to march out of BG city: make Biff comment while waiting to leave */
-EXTEND_TOP ~bd0101.bcs~ ~%MOD_FOLDER%/baf/bd0101_commenting.baf~
+EXTEND_TOP ~bd0101.bcs~ ~%MOD_FOLDER%/baf/bd0101_commenting_et.baf~
   EVALUATE_BUFFER
 	</pre>
 
-      <h2><a name="toc_6">Biff should move when the coalition starts marching out of BG city</a></h2>
+      <h2><a name="toc_6">6. Biff should move when the coalition starts marching out of BG city</a></h2>
       <p>When everyone starts marching out of the city to face the crusade, all NPCs not in the group start moving towards the southeast area exit until the scene fades to black.</p> 
 	  <p>We patch this to <strong>bdcut08.bcs</strong> so Biff will move, too:</p>
 	 <pre class="code">  
@@ -497,7 +515,7 @@ THEN
 		ApplySpellRES("BDSLOW",Myself)  // sets the movement rate to "6" for 15 realtime seconds
 		Wait(2)
 		SmallWait(109)
-		MoveToPoint([xxx.yyy]) //chose a point in direction of the southeast area exit, depending on where your NPC is waiting
+		MoveToPoint([1090.1100]) //leave these in or chose a point in direction of the southeast area exit of bd0010.are, depending on where your NPC is waiting.
 END
 	</pre>
      <p>And the according tp2 patching (note the EXTEND_TOP):</p>
@@ -508,11 +526,11 @@ EXTEND_TOP ~bdcut08.bcs~ ~%MOD_FOLDER%/baf/xxbdcut08.baf~
 	</pre>	
 	
 	
-	     <h2><a name="toc_brexp">Reaction to the destroyed Bridge at Coastway Crossing</a></h2>
-	  <p>The actual commenting on the destruction of the bridge is in bdcut14.bcs, but the cutscene is such that it either needs to be patched using REPLACE_TEXTUALLY or somesuch to bring NPC reactions in the middle, or the NPC reactions need to be put elsewhere. I decided to put them into the NPC OVERRIDE script so they trigger after the cutscene, when the intermediate fight with the crusaders trapped on the PC's side of the bridge starts. This is also why this time, the trigger does not contain a "CombatCounter(0)". This might delay NPC's ai fighting reactions since there is enemies right in front of them, but I couldn't detect any measurable effect while playing:</p>	
+	     <h2><a name="toc_brexp">7. Reaction to the destroyed Bridge at Coastway Crossing</a></h2>
+	  <p>The actual commenting on the destruction of the bridge is in bdcut14.bcs, but the cutscene is such that it either needs to be patched using REPLACE_TEXTUALLY or somesuch to bring NPC reactions in the middle, or the NPC reactions need to be put elsewhere. I decided to put them into the NPC's OVERRIDE script so they trigger after the cutscene, when the intermediate fight with the crusaders trapped on the PC's side of the bridge starts. This is also why this time, the trigger does not contain a "CombatCounter(0)". This might delay NPC's ai fighting reactions since there is enemies right in front of them, but I couldn't detect any measurable effect while playing:</p>	
 	 <pre class="code">  
-/* This goes into Biff's SoD script */
-/* (T3) bd1000: Biff comments on the explosion on the bridge  */
+/* This goes into Biff's SoD OVERRIDE script */
+/* bd1000: Biff comments on the explosion on the bridge  */
 IF
 	GlobalTimerNotExpired("bd_caelar_timer","bd1000")
 	AreaCheck("bd1000")
@@ -526,7 +544,7 @@ THEN
 END
 	</pre>
 	
-		     <h2><a name="toc_cael1">Comment after seeing Caelar at Coastway Crossing</a></h2>
+		     <h2><a name="toc_cael1">8. Comment after seeing Caelar at Coastway Crossing</a></h2>
 	  <p>After meeting Caelar across the Coastway Crossing Bridge, the NPCs have a comment on her via <strong>bd1000.bcs</strong>.</p>		  
 	 <p class="info">These comments will only show before the Flaming Fist soldiers and Bence Duncan attracted by the explosion will initiate dialogue which will happen if any party member comes near the exit by the tent at the bridge. Depending on how the group fight the trapped crusaders, this could be directly after the meeting happened, and no comments on Caelar will show. If you want your NPC comment on Caelar independent to this, you need to broaden the trigger a bit.</p>
 	  <p>This will be patched to bd1000.bcs:<p>
@@ -553,26 +571,27 @@ END
 EXTEND_BOTTOM ~bd1000.bcs~ ~%MOD_FOLDER%/baf/bd1000_commenting.baf~
   EVALUATE_BUFFER
 	</pre>
-		  <h2><a name="toc_killsp">PC killed Crusaders using the Spikes Trap in Temple of Bhaal (good aligned NPCs)</a></h2>
+		  <h2><a name="toc_killsp">9. PC killed Crusaders using the Spikes Trap in Temple of Bhaal (good aligned NPCs)</a></h2>
 	  <p>Inside the old temple of Bhaal (bd7230.are) there are three crusaders trapped in cages. A lever to the left will activate a spike trap in those cages, killing the three crusaders inside. The PC can either activate the trap by clicking on the lever twice. Before doing that, the PC can also threaten the crusaders with doing this.</p>
-	  <p>If the lever is pulled twice and the crusaders killed that way, a PC being PALADIN or RANGER will fall.</p>
+	  <p class="info">If the lever is pulled twice and the crusaders killed that way, a PC being PALADIN or RANGER will fall. Please note: because of how it is scripted, clicking on the lever while having more than one group member selected is counted by the engine as more than one click - and the spike trapp will be activated even if the player clicked only once!</p>
 	  <p>If the PC choses the threatening reply option it is only Rasaad who will react to the threat (and Dorn replying to Rasaad if present). But seeing how using the lever to kill the crusaders will lead to a fall of paladin- and rangerhood of the PC tells me that this is a situation where good aligned NPCs should react, and strongly.<p>
 	  <p>So, Biff will do two things to serve as an example for other mod NPCs:<p>
 	  <ol>
         <li>Biff will comment on the threat in the crusader's dialogue (BDKHARMY.dlg state 6).</li>
         <li>Biff will have a comment as floating text in case the spike trap is activated to kill the crusaders.</li>
 	  </ol>	  
-	  <p>The comment into the dialogue is a simple I_C_T that needs to be put into a .d-file:<p>	  
-	 <pre class="code">  
-/* (T3) PC threatens to kill the crusaders with the spikes in bd7230.are */
+	  <p>The comment into the dialogue is a simple I_C_T that needs to be put into a .d-file. In the tutorial mod package it is called <strong>sod_event_comments.d</strong>:<p>	  
+	 <pre class="code"> 
+/* put this into sod_event_comments.d */	 
+/* PC threatens to kill the crusaders with the spikes in bd7230.are */
 I_C_T bdkharmy 6 xxBiff_bdkharmy_6
-== xxBiffsJ IF ~IsValidForPartyDialogue("xxBiff")~ THEN ~Wow, eeeevil.~
+== xxBiffJ IF ~IsValidForPartyDialogue("xxBiff")~ THEN ~Wow, eeeevil.~
 END
 	</pre>
 	  <p>For the reaction to the usage of the spike trap, we need to patch the script <strong>bdlever2.bcs</strong> so it sets a variable we can use for detection. For this, we add to the tp2:<p>	  
 	 <pre class="code">  
 /* React in case crusaders in cages are killed by spikes (bd7230.are) */
-//bdlever2.BCS
+/* Patch bdlever2.bcs */
 COPY_EXISTING ~bdlever2.BCS~ ~override~
 	DECOMPILE_AND_PATCH BEGIN
 		SPRINT textToReplace ~\(Kill("bdkharmy")\)~
@@ -606,26 +625,26 @@ END
 	</pre>
 	
 	
-	      <h2><a name="toc_surBFC">PC surrendered Bridgefort to the Crusaders (good aligned NPCs)</a></h2>
+	      <h2><a name="toc_surBFC">10. PC surrendered Bridgefort to the Crusaders (good aligned NPCs)</a></h2>
 	  <p>In chapter 9, the PC has the opportunity to hand over Bridgefort to the crusaders without a fight. Good aligned NPCs in the party will call this a betrayal. First, Corwin will speak up, then Khalid. Neera, Rasaad, Dynaheir, and Minsc will chime in depending on the PC's replies, and finally Jaheira.</p>	 
       <p>If Corwin is not in the party, the dialogue will be started by Khalid and the other NPCs will chime in as described. If Khalid is not in the party, then Jaheira, Minsc, and Rasaad will have their dialogue lines as DisplayStringHeads, instead.</p>
 	  <p>So, we want two things for Biff: if Khalid is in the group and able to talk, we want Biff to say his comment after Khalid's first line. If Khalid is not able to talk, Biff should have his comment as a floating text above his head - but after Corwin spoke her line if she is in party and able to talk.</p>
 	  <p>To achieve this, we need to consider the following: 	  	    
 	  <ol>
-        <li>The text line will be the same in both cases, but one will go into Biff's joined dialogue xxBiffsJ.dlg and one into the area script bd2000.bcs.</li>
+        <li>The text line will be the same in both cases, but one will go into Biff's joined dialogue xxBiffJ.dlg and one into the area script bd2000.bcs.</li>
         <li>And, for the I_C_T into Khalid's joined dialogue BDKHALIJ.dlg we use the same global variable name than we will for the DisplayStringHead in the script.</li>
 	  </ol> </p>
-	  <p>This is what we put into a .d file:</p>
+	  <p>This is what we put into a .d file. In the tutorial mod package it is called <strong>sod_event_comments.d</strong>:</p>
 	 <pre class="code">  
 /* PC handed over the Bridgefort Castle to the crusaders */
 
 I_C_T BDKHALIJ 33 xxBiff_betrayal_discussion //"xxBiff_betrayal_discussion" is the name of the global variable
-== xxBiffsJ IF ~IsValidForPartyDialogue("xxBiff")~ THEN ~Well, this was definitely faster.~
+== xxBiffJ IF ~IsValidForPartyDialogue("xxBiff")~ THEN ~Well, this was definitely faster.~
 END
 	</pre>
 	  <p>This is what we will patch to <strong>bd2000.bcs</strong> via EXTEND_TOP:</p>
 	 <pre class="code">  
-/* xxbd2000_commenting */
+/* xxbd2000_commenting_et.baf */
 /* PC surrendered Bridgefort to the Crusaders */
 IF
 	Global("bd_plot","global",260)
@@ -641,39 +660,40 @@ THEN
 		SetGlobal("xxBiff_betrayal_discussion","bd2000",1)
 		SetGlobalTimer("bd_betrayal_discuss_timer","bd2000",ONE_MINUTE) //to space all the other NPC comments
 		DisplayStringHead("xxBiff",~Well, this was definitely faster.~)
+		Continue()
 END
 	</pre>
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
 /* (T3) PC gave Bridgefort Castle to the crusaders */
-EXTEND_TOP ~bd2000.bcs~ ~%MOD_FOLDER%/baf/xxbd2000_commenting.baf~
+EXTEND_TOP ~bd2000.bcs~ ~%MOD_FOLDER%/baf/xxbd2000_commenting_et.baf~
   EVALUATE_BUFFER
 	</pre>
 	
 		
-      <h2><a name="toc_8">Comment in random area (Canyon Ambush) bd0063.are</a></h2>
+      <h2><a name="toc_8">11. Comment in random area (Canyon Ambush) bd0063.are</a></h2>
 	  <p>The random encounter area bd0063.are features an ambush inside a canyon. Some of the NPCs have a comment here: Minsc or Corwin will state the possibility of an ambush, and either Edwin, Baeloth, Dynaheir, or Neera will inform the PC that it's a dead magic zone. This is done in a way that either one NPC of each of the two groups will speak randomly, and only if this didn't happen (because the NPC in question is not in party), each one of the NPCs are called in extra script blocks directly in case the random script blocks didn't trigger.</p>	
 	  <p>We will not touch the random script blocks as patching them will not be possible in a compatible manner for more than one NPC mod, but we will add a script block so that our NPC can state the obvious in case the original NPCs are not present.</p>	
 	  <p>In case you want your NPC to steal the show, you could patch the script addition via EXTEND_TOP - then your NPC will be the one stating the warning, unless another mod NPC installed after yours did the same. I decided to play nice and add Biff's comments at the end, so they will only show if none of the 6 mentioned NPCs of the two groups are present.</p>
 	 <p class="info">Of course you can make your NPC say something in addition to the other ones. In this case you need to use own trigger variables for the commenting script blocks and using EXTEND_BOTTOM is sufficient.</p>
 	  <p>This is what we will patch to <strong>bd0063.bcs</strong>. It contains both script blocks, one for a fighter who would warn about the place being a good ambush point and the second for a mage who would warn about the place being a dead magic zone:</p>
 	 <pre class="code">  
-/* xxbd0063.baf */
+/* xxbd0063_commenting.baf */
 
 /* Warn about the place being a good ambush point: */
 IF
-	Global("BD_NPC02","MYAREA",0)
+	Global("BD_NPC02","MYAREA",0) //neither Minsc nor Corwin gave a warning about a possible ambush
 	IfValidForPartyDialog("xxBiff")  
 	Delay(3)
 THEN
 	RESPONSE #100
-		SetGlobal("BD_NPC02","MYAREA",1)
+		SetGlobal("BD_NPC02","MYAREA",1) 
 		DisplayStringHead("xxBiff",~This looks like the ambush site we are supposed to encounter~)  
 END
 
-/* Warn about the place being a a dead magic zone (mages only): */
+/* Warn about the place being a dead magic zone (mages only): */
 IF
-	Global("BD_NPC01","MYAREA",0)
+	Global("BD_NPC01","MYAREA",0) //neither Edwin, Baeloth, Dynaheir, nor Neera gave a warning about dead magic zone
 	IfValidForPartyDialog("xxBiff")  
 	Delay(3)
 THEN
@@ -685,13 +705,12 @@ END
 	  <p>And the tp2 patching:</p>	  
 	 <pre class="code">  
 /* (T3) Comment in random area (Canyon Ambush) bd0063.are */
-EXTEND_BOTTOM ~bd0063.bcs~ ~%MOD_FOLDER%/baf/xxbd0063.baf~
+EXTEND_BOTTOM ~bd0063.bcs~ ~%MOD_FOLDER%/baf/xxbd0063_commenting.baf~
 EVALUATE_BUFFER
-	</pre>
+	</pre>	
 	
 	
-	
-      <h2><a name="toc_9">Comment after killing the Rhinoceros Beetle in bd0114.are</a></h2>
+      <h2><a name="toc_9">12. Comment after killing the Rhinoceros Beetle in bd0114.are</a></h2>
 	  <p>In the spider cave (bd0114.are) a giant beetle will appear. After killing it, all party members will comment. A timer helps to space the comments appropriately.</p>	
 	  <p>This is what we will patch to <strong>bd0114.bcs</strong>:</p>
 	 <pre class="code">  
@@ -716,12 +735,11 @@ EVALUATE_BUFFER
 	</pre>	
 	
 	
-	
-	      <h2><a name="toc_10">Comment when Battle at Bridgefort starts</a></h2>
+	      <h2><a name="toc_10">13. Comment when Battle at Bridgefort starts</a></h2>
 	  <p>When the battle for Bridgefot starts, all NPC will have a comment.</p>
 	  <p>This is what we will patch to <strong>bd2000.bcs</strong>:</p>
 	 <pre class="code">  
-/* xxbd2000_commenting_2.baf */
+/* xxbd2000_commenting.baf */
 /* Battle at Bridgefort starts */
 IF
 	Global("bd_plot","global",250)
@@ -738,24 +756,23 @@ END
 	</pre>
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
-/* (T3) PC gave Bridgefort Castle to the crusaders */
-EXTEND_BOTTOM ~bd2000.bcs~ ~%MOD_FOLDER%/baf/xxbd2000_commenting_2.baf~
+/* Battle at Bridgefort starts */
+EXTEND_BOTTOM ~bd2000.bcs~ ~%MOD_FOLDER%/baf/xxbd2000_commenting.baf~
   EVALUATE_BUFFER
 	</pre>
 	
 	
-      <h2><a name="toc_11">Comments in bd4300.are (Bridgefort Castle interior and Avernus portal)</a></h2>
-	  <p>In bd4300.bcs happen several things so I decided to put them into the same baf file.</p>
-	  <p>The topic "Portal is opened after Hephernaan's scheme" is not an official commenting point for the NPCs, but I added it in case you want to let your NPC comment on that, too.</p>	  	  
+      <h2><a name="toc_11">14. Comments in bd4300.are (Bridgefort Castle interior and Avernus portal)</a></h2>
+	  <p>In bd4300.bcs happen several things so I decided to put them into the same baf file.</p>  
 	  <ol>
         <li>Hephernaan discovered the group inside the castle</li>
-        <li>Portal is opened after Hephernaan's scheme</li>
+        <li>Portal is opened after Hephernaan's scheme. This is not an official commenting point for the NPCs, but I added it in case you want to let your NPC comment on that, too.</li>
         <li>PC killed the crusaders at the portal</li>
         <li>Comment after first wave of demons if PC lingers</li>
         <li>Comment after return from Avernus: portal is closed</li>
 	  <p>This is what we will patch to <strong>bd4300.bcs</strong>:</p>
 	 <pre class="code">  
-/* xxbd4300_commenting.baf */
+/* xxbd4300_commenting_et.baf */
 /* 1 Hephernaan discovered the group inside the castle */
 IF
 	Global("bd_plot","global",370)
@@ -827,14 +844,14 @@ END
 	</pre>
 	  <p>And the tp2 patching via EXTEND_TOP:</p>
 	 <pre class="code">  
-/* (T3) Comments in bd4300.are (Bridgefort Castle interior and Avernus portal) */
-EXTEND_TOP ~bd4300.bcs~ ~%MOD_FOLDER%/baf/xxbd4300_commenting.baf~
+/* Comments in bd4300.are (Bridgefort Castle interior and Avernus portal) */
+EXTEND_TOP ~bd4300.bcs~ ~%MOD_FOLDER%/baf/xxbd4300_commenting_et.baf~
 EVALUATE_BUFFER
 	</pre>
 		
-      <h2><a name="toc_12">Comment upon entering Avernus</a></h2>
-	  <p>Upon entering the portal and reaching Avernus, up to three NPCs will have give a comment. The chances of original NPCs talking is reduced to 50% by giving two RESPONSE #50 action blocks.</p>	
-	  <p>Our NPC will say their piece in addition- If you want your NPC to give their comment always, you need to remove one of the #50 action blocks and change the percetage to #100 as indicated below.</p>
+      <h2><a name="toc_12">15. Comment upon entering Avernus</a></h2>
+	  <p>Upon entering the portal and reaching Avernus, up to three NPCs will give a comment. The chances of original NPCs talking is reduced to 50% by giving two RESPONSE #50 action blocks.</p>	
+	  <p class="info">Our NPC will say their piece in addition, but also only with a 50% chance. If you want your NPC to give their comment always, you need to remove one of the #50 action blocks and change the percetage to #100 as indicated below.</p>
 	  <p>This is what we will patch to <strong>bd4400.bcs</strong>:</p>
 	 <pre class="code">  
 /* xxbd4400_commenting.baf */
@@ -854,16 +871,16 @@ END
 	</pre>
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
-/* (T3) Comment upon entering Avernus */
+/* Comment upon entering Avernus */
 EXTEND_BOTTOM ~bd4400.bcs~ ~%MOD_FOLDER%/baf/xxbd4400_commenting.baf~
 EVALUATE_BUFFER
 	</pre>
 		
-      <h2><a name="toc_13">Comment in the Avernus Elevator</a></h2>
+      <h2><a name="toc_13">16. Comment in the Avernus Elevator</a></h2>
 	  <p>Inside Avernus, the group has to use an elevator. Between the demon showers, the NPCs comment on it.</p>	
 	  <p>This is what we will patch to <strong>bd4601.bcs</strong>:</p>
 	 <pre class="code">  
-/* xxbd4601_commenting.baf */
+/* xxbd4601_commenting_et.baf */
 /* Comment in the Avernus Elevator */
 IF
 	Global("xxBiff_bd_hellevator_ot","bd4601",0)  
@@ -874,18 +891,19 @@ THEN
 	RESPONSE #100
 		SetGlobal("xxBiff_bd_hellevator_ot","bd4601",1)  // Avernus Elevator
 		SetGlobalTimer("bd_hellevator_timer","bd4601",7)  
-		DisplayStringHead("xxBiff",~Better not be afraid of heights!~)  
+		DisplayStringHead("xxBiff",~Better not be afraid of heights! ... And demons.~)   
+		Continue()
 END
 	</pre>
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
 /* Comment in the Avernus Elevator */
-EXTEND_TOP ~bd4601.bcs~ ~%MOD_FOLDER%/baf/xxbd4601_commenting.baf~
+EXTEND_TOP ~bd4601.bcs~ ~%MOD_FOLDER%/baf/xxbd4601_commenting_et.baf~
 EVALUATE_BUFFER
 	</pre>
 		
-      <h2><a name="toc_14">Comment before entering the Cave with the blind Wyrmlings (bd5100aw.bcs)</a></h2>
-	  <p>In the Underground River area (bd5100.are) there is a cave with three blind wyrmlings inside. Either Jaheira, Dynaheir, Minsc (and theoretically also M'Khiin, albeit the trigger script is faulty in 2.5 because it calls the wrong script name for her) will give a comment upon reaching the entrance to the cave about "Pain and sorrow knot together" (Dynaheir), "a powerful anger" (Jaheira), "Boo is restless" (Minsc), or "So much rage in the air" (M'Khiin). How the NPCs got their 6th sense I don't know, also why it is this choice of NPCs. Nevertheless, if your NPC should give a warning too, here is a way to script it so that your NPC speaks if none of the other does. </p>	  
+      <h2><a name="toc_14">17. Comment before entering the Cave with the blind Wyrmlings (bd5100aw.bcs)</a></h2>
+	  <p>In the Underground River area (bd5100.are) there is a cave with three blind wyrmlings inside. Either Jaheira, Dynaheir, Minsc, or M'Khiin will give a comment upon reaching the entrance to the cave about "Pain and sorrow knot together" (Dynaheir), "a powerful anger" (Jaheira), "Boo is restless" (Minsc), or "So much rage in the air" (M'Khiin). How the NPCs got their 6th sense I don't know, neither why it is this choice of NPCs. Nevertheless, if your NPC should give a warning too, here is a way to script it so that your NPC speaks if none of the other does. </p>	  
 	 <p class="info">If your NPC should speak up in addition to one of the original ones you need to remove the original variable Global("BD_SDD317_WYRMS","BD5100",0) out of the script block. Also, the comment could be done via DisplayStringHead instead of calling a real dialogue line.</p>
 	  <p>This is what we will patch to <strong>bd5100aw.bcs</strong>:</p>
 	 <pre class="code">  
@@ -909,7 +927,7 @@ END
 	</pre> 
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
-/* (T3) Comment before entering the Cave with the blind Wyrmlings (bd5100aw.bcs) */
+/* Comment before entering the Cave with the blind Wyrmlings (bd5100aw.bcs) */
 EXTEND_BOTTOM ~bd5100aw.bcs~ ~%MOD_FOLDER%/baf/xxbd5100aw_commenting.baf.baf~
 EVALUATE_BUFFER
 	</pre>	
@@ -927,7 +945,7 @@ END //APPEND
 
 	</pre>
 		
-      <h2><a name="toc_15">Comment after killing the blind Wyrmlings in Cave (bd0113.bcs)</a></h2>
+      <h2><a name="toc_15">18. Comment after killing the blind Wyrmlings in Cave (bd0113.bcs)</a></h2>
 	  <p>After the three blind wyrmlings in the cave (bd0113.are) are killed, Jaheira or Corwin will have a remark. I put the according trigger here in case you want your NPC to comment, too.</p>	
 	  <p>This is what we will patch to <strong>bd0113.bcs</strong> to trigger the dialogue:</p>
 	 <pre class="code">  
@@ -936,7 +954,9 @@ END //APPEND
 IF
 	StateCheck("BDWYRMLI",STATE_REALLY_DEAD)  // Blind Albino Wyrmling
 	NumDeadGT("BDWYRML1",2)  // Blind Albino Wyrmling
-	Global("BD_SDD317_WYRMS","BD5100",3) //remove this if your NPC should talk in addition to Jaheira or Corwin
+	GlobalGT("BD_SDD317_WYRMS","BD5100",2) //remove this if your NPC should talk in addition to Jaheira or Corwin
+	!IfValidForPartyDialog("JAHEIRA")  //remove this if your NPC should talk in addition to Jaheira or Corwin
+	!IfValidForPartyDialog("CORWIN")  //remove this if your NPC should talk in addition to Jaheira or Corwin
 	GlobalLT("xxBiff_BD_SDD317_WYRMS","BD5100",3)
 	CombatCounter(0)
 THEN
@@ -947,7 +967,7 @@ END
 	</pre>
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
-/* (T3) Comment after killing the blind Wyrmlings in Cave (bd0113.bcs) */
+/* Comment after killing the blind Wyrmlings in Cave (bd0113.bcs) */
 EXTEND_BOTTOM ~bd0113.bcs~ ~%MOD_FOLDER%/baf/xxbd0113_commenting.baf~
 EVALUATE_BUFFER
 	</pre>	
@@ -965,7 +985,7 @@ END //APPEND
 
 	</pre>	
 		
-      <h2><a name="toc_16">Comment when battle starts in Kanaglym (bd5300.are, Underground River)</a></h2>
+      <h2><a name="toc_16">19. Comment when battle starts in Kanaglym (bd5300.are, Underground River)</a></h2>
 	  <p>In one of the areas in the Underground River, Kanaglym (bd5300.are) the group has to fight a necromancer and his ghost dragon. The NPCs give a shout when the fight starts.</p>	 
 	  <p>This is what we will patch to <strong>bd5300.bcs</strong>:</p>
 	 <pre class="code">  
@@ -973,31 +993,32 @@ END //APPEND
 /* Comment when battle starts in Kanaglym (bd5300.are, Underground River) */
 IF
 	Global("BD_AREA_HOSTILE","BD5300",1)  // Kanaglym
-	!GlobalTimerNotExpired("bd_sdd350b_ot_timer","bd2000")  // This timer has the area code from Boareskyr Bridge & Bridgefort - I *think* this is a bug but I'll leave it for now. Needs to be checked for v2.6
+	!GlobalTimerNotExpired("bd_sdd350b_ot_timer","bd5300")  // The original timer has the area code from Boareskyr Bridge & Bridgefort - I *think* this is a bug so I corrected it
 	Global("xxBiff_bd_ot","bd5300",0)  
 	IfValidForPartyDialog("xxBiff")  
 	TriggerOverride("xxBiff",Range([ENEMY.0.0.0.HOSTILES3],30))
 THEN
 	RESPONSE #100
-		SetGlobalTimer("bd_sdd350b_ot_timer","bd2000",THREE_MINUTES)  // see above to comment about timer 
+		SetGlobalTimer("bd_sdd350b_ot_timer","bd5300",THREE_MINUTES)  // The original timer has the area code from Boareskyr Bridge & Bridgefort - I *think* this is a bug so I corrected it
 		SetGlobal("xxBiff_bd_ot","bd5300",1)  
 		DisplayStringHead("xxBiff",~Here we go!~)
 END
 	</pre>
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
-/* (T3) Comment when battle starts in Kanaglym (bd5300.are, Underground River) */
+/* Comment when battle starts in Kanaglym (bd5300.are, Underground River) */
 EXTEND_BOTTOM ~bd5300.bcs~ ~%MOD_FOLDER%/baf/xxbd5300_commenting.baf~
 EVALUATE_BUFFER
 	</pre>		
 		
-      <h2><a name="toc_17">Last area bd6100.are: comment in abduction scene (EET)</a></h2>
+      <h2><a name="toc_17">20. Last area bd6100.are: comment in abduction scene (EET)[DEPRECATED]</a></h2>
+	  <p class="info">This section is deprecated alongside the according components to move the NPC at the end of SoD described in Tutorial 2 ("Make Your NPC Comment and Move Along at the End of SoD"). I'll leave it in so anyone interested can try to make this work without having to search for the involved scripts anew.</p>
 	  <p>SoD comes with an abduction cutscene at the end which is disabled for the original product. EET restores this cutscene, as does one component of my Jastey's SoD Tweak Pack.</p>	
-	  <p>The group in the last game area is attacked by hooded figures, and three party members give two comments depending on the moment (one for being attacked, one when they lose consciousness). The following code will give our NPC comments in addition to the three original group members if the NPC is in the group.</p>	  
+	  <p>The group in the last game area is attacked by hooded figures, and two comments can be said by three NPCs each depending on the moment (one for being attacked, one when they lose consciousness). The following code will add comments for our NPC in addition to the three original group members if the NPC is in the group.</p>	  
 	  <p>Both script blocks make the NPC comment with a 33% chance. If you want your NPC to comment always, you need to remove the extra RESPONSE #200 Continue() action block.</p>  
 	  <p>This is what we will patch to <strong>bd6100.bcs</strong>:</p>
 	 <pre class="code">  
-/* xxbd6100_commenting.baf */
+/* xxbd6100_commenting_et.baf */
 /* Last area bd6100.are: comment in abduction scene (for EET or SoD with Jastey's SoD Tweak Pack) */
 
 
@@ -1037,12 +1058,12 @@ END
 	  <p>And the tp2 patching via EXTEND_TOP:</p>
 	 <pre class="code">  
 /* End of SoD - Comment in Abduction Scene */
-EXTEND_TOP ~bd6100.bcs~ ~%MOD_FOLDER%/baf/xxbd6100_commenting.baf~
+EXTEND_TOP ~bd6100.bcs~ ~%MOD_FOLDER%/baf/xxbd6100_commenting_et.baf~
 EVALUATE_BUFFER
 	</pre>
 		
 		
-      <h2><a name="toc_18">Comment in Dragonspear Castle Exterior</a></h2>
+      <h2><a name="toc_18">21. Comment in Dragonspear Castle Exterior</a></h2>
 	  <p>In the Dragonspear Castle exterior area (bd4000.are) after freeing the castle, Glint, Minsc, and Corwin react when reaching the top of the stairs beside the huge dragon skelleton.</p>	
 	  <p>To let our NPC comment, too, we need to patch the trigger script bdbark01.bcs.</p>
 	  <p>This is what we will patch to <strong>bdbark01.bcs</strong>:</p>
@@ -1069,9 +1090,9 @@ EVALUATE_BUFFER
 	</pre>
 		
 		
-      <h2><a name="toc_19">Move the PC in the cutscene of the plotting nobles in Three Old Kegs (bdc116d.bcs)</a></h2>
+      <h2><a name="toc_19">22. Move the PC in the cutscene of the plotting nobles in Three Old Kegs (bdc116d.bcs)</a></h2>
 	  <p>When the PC interacts with the plotting nobles in the Three Kegs there is a cutscene which gets called twice which places the party NPCs inside the northwest room where the confrontation with the Flaming Fist takes place. Unfortunately, instead of just using the general Player2-6 the script works with the explicit NPC names that are available until then - Safana, Minsc, and Dynahier. We need to add our NPC explicitely, too.</p>
-	  <p class="info">This is only needed for your NPC if they are  already available inside Baldur's Gate city.</p> 
+	  <p class="info">This is only needed for your NPC if they are already available inside Baldur's Gate city.</p> 
 	  <p>This is what we will patch to <strong>bdc116d.bcs</strong>:</p>
 	 <pre class="code">  
 /* xxbdc116d.baf */
@@ -1083,7 +1104,7 @@ THEN
 	RESPONSE #100
 		CutSceneId("xxBiff")  
 		JumpToPoint([xx.yy]) //use coordinates at the left side of the northwest room. For example, Minsc is placed at [296.246]
-		Face(Z) //adjust facing position accordingly, so the NPC looks into the room
+		Face(E) //adjust facing position accordingly, so the NPC looks into the room
 END
 
 IF
@@ -1092,20 +1113,20 @@ IF
 THEN
 	RESPONSE #100
 		CutSceneId("xxBiff")  
-		JumpToPoint([xx.yy]) //use coordinates at the left side of the northwest room. For example, Minsc is placed at [424.186]
-		Face(Z) //adjust facing position accordingly, so the NPC looks into the room
+		JumpToPoint([xx.yy]) //use coordinates in the middle of the northwest room. For example, Minsc is placed at [424.186]
+		Face(E) //adjust facing position accordingly, so the NPC looks into the room
 END
 	</pre>
 	  <p>And the tp2 patching:</p>
 	 <pre class="code">  
 /* Move the PC in the cutscene of the plotting nobles in Three Old Kegs (bdc116d.bcs) */
-EXTEND_BOTTOM ~bdc116d.bcs~ ~%MOD_FOLDER%/baf/xxbdc116d.baf~
+EXTEND_TOP ~bdc116d.bcs~ ~%MOD_FOLDER%/baf/xxbdc116d.baf~
 EVALUATE_BUFFER
 	</pre>
 	
 			
 		
-      <h2><a name="toc_20">Comment on closed vault door (to portal) in Dragonspear Castle Interior</a></h2>
+      <h2><a name="toc_20">23. Comment on closed vault door (to portal) in Dragonspear Castle Interior</a></h2>
 	  <p>When reaching the closed doors before the portal, one of the original NPC comment on how evil they look.</p>	  
 	  <p>This is what we will patch to <strong>bdvaultd.bcs</strong> so our NPC makes a comment in case none of the original NPCs is present:</p>
 	 <pre class="code">  
@@ -1118,8 +1139,8 @@ IF
 	Range("xxBiff",25)  
 THEN
 	RESPONSE #100
-		SetGlobal("bd_MDD893a_ot","bd4300",1)  // if your NPC should comment in addition, change this to a unique variable with your prefix as above
-		DisplayStringHead("xxBiff",~Huge, evil doors. Well, not the doors, but what lays behind.~)  
+		SetGlobal("bd_MDD893a_ot","bd4300",1)  // if your NPC should comment in addition, change this to the same unique variable with your prefix like above
+		DisplayStringHead("xxBiff",~Huge, evil doors. Well, not the doors, but what lies behind.~)  
 END
 
 	</pre>
@@ -1132,13 +1153,13 @@ EVALUATE_BUFFER
 	
 				
 		
-      <h2><a name="toc_21">Avernus: Thrix' Game</a></h2>
-	  <p>In Avernus in front of the great door to the great endboss a fiend names Thrix will want to play a game with the PC: he gets a soul from either one of the group members if the PC loses, and the PC gets a weapon if saying the correct answer.</p>	
-<p>To determine which NPC Thrix proposes for taking the soul, the dialogue pretends a certain randomness which we will try to preserve with our addition for our NPC. Since the chosing of the NPC(s) is not done with real randomness, what we will do is add our NPC to each of the 4 corresponding dialogue blocks with which the randomness is simulated.</p>	
-<p>To be precise, we will add our NPC to the bottom of the first, the top of the second, at position 10 of the third and position 5 of the 4th. This way, it will not be our NPC that gets chosen every time and the outcome is somewhat unpredictable, which gives enough credit to how Thix' dialogue is coded.</p> 
-<p>This tutorial shows the standard case: Thrix will chose our NPC, the PC can either accept, request that Thrix choses another, offer their own soul, or attack. If our NPC is chosen and the PC accepts, there will be a follow-up dialogue of our NPC.</p>
- <p class="info">Of course, there can be other possibilities as well: Thrix can first ponder your NPC but then decide not to take them himself, and the NPC can also react to the PC offering his own soul etcpp.</p>
- <p>The variable Global("xxBiff_SoDThrix","GLOBAL") is used as follows. We do not need all the variants for what we do in this tutorial, but this way, you have all you need to let your NPC react to all outcomes.</p>
+     <h2><a name="toc_21">24. Avernus: Thrix' Game</a></h2>
+	 <p>In Avernus in front of the great door to the great endboss a fiend names Thrix will want to play a game with the PC: he gets a soul from either one of the group members if the PC loses, and the PC gets a weapon if saying the correct answer.</p>	
+	 <p>To determine which NPC Thrix proposes for taking the soul, the dialogue pretends a certain randomness which we will try to preserve with our addition for our NPC. Since the chosing of the NPC(s) is not done with real randomness, what we will do is add our NPC to each of the 4 corresponding dialogue blocks with which the randomness is simulated.</p>	
+	 <p>To be precise, we will add our NPC to the bottom of the first, the top of the second, at position 10 of the third and position 5 of the 4<sup>th</sup>. This way, it will not be our NPC that gets chosen every time and the outcome is somewhat unpredictable, which gives enough credit to how Thix' dialogue is coded.</p> 
+	 <p>This tutorial shows the standard case: Thrix will chose our NPC, the PC can either accept, request that Thrix choses another, offer their own soul, or attack. If our NPC is chosen and the PC accepts, there will be a follow-up dialogue of our NPC.</p>
+	 <p class="info">Of course, there can be other possibilities as well: Thrix can first ponder your NPC but then decide not to take them himself, and the NPC can also react to the PC offering his own soul etcpp. Feel free to expand on the example, as always.</p>
+	 <p>The variable Global("xxBiff_SoDThrix","GLOBAL") is used as follows. We do not need all the variants for what we do in this tutorial, but this way, you have all you need to let your NPC react to all outcomes.</p>
       <ol>
         <li>Global("xxBiff_SoDThrix","GLOBAL",0): Biff was not chosen in Thrix' game.</li>
         <li>Global("xxBiff_SoDThrix","GLOBAL",1): Biff was chosen and the PC accepted it, but either won the game [there is a game variable to detect that, see below] or tried to fight the demon off after losing.</li>
@@ -1147,13 +1168,14 @@ EVALUATE_BUFFER
         <li>Global("xxBiff_SoDThrix","GLOBAL",4): Biff was chosen before the riddle and the PC sent him off to Thrix (verbally) after losing.</li>
         <li>Global("xxBiff_SoDThrix","GLOBAL",5): Biff was chosen but the PC decided to fight the demon before the riddle.</li>
       </ol> 
- <p>There are the following variables we can use and track in the game:</p>
+	 <p>There are the following variables we can use and track in the game:</p>
       <ol>
         <li>Global("BD_Thrix_riddle_won","GLOBAL",1): PC won the riddle.</li>
         <li>Global("bd_thrix_sacrifice_companion","global",1): PC offered/accepted an NPC's soul.</li>
-        <li>Global("bd_thrix_sacrifice_self","global",1): PC offered own soul.</li>
+        <li>Global("bd_thrix_sacrifice_self","global",1): PC offered their own soul.</li>
       </ol> 
-	  <p>This is what we will put into a .d file:</p>
+	  <p>This is what we will put into a .d file. In the tutorial mod package it is called <strong>sod_event_comments.d</strong>.</p>
+	  <p class="info">The "DO 2 IF ~!Is?f?ValidForPartyDialogue("Rasaad")~" at the end of the ADD_TRANS_TRIGGER syntax makes sure the third reply option (counted from the top starting with "0") will only be patched if it's the correct one containing the check whether no NPC in party is able to talk. This means that if another mod shifted the reply option numbers, nothing will be patched. Look at argent77's function GET_RESPONSE_STRREFS to identify and patch the correct response in a dialogue state even if their numbers were shifted: <a href="https://www.gibberlings3.net/forums/topic/28835-toss-your-semi-useful-weidu-macros-here/page/9/#comment-297371">(and following posts) [How-To] "GET_RESPONSE_STRREFS function - finding the correct original game reply option number of a certain state number if knowing the stringref number of that reply option", by argent77</a></p>
 	 <pre class="code">  
 /* Thrix's game */
 /* Thrix will not propose gamble if there is no NPC available: add Biff here */
@@ -1193,9 +1215,9 @@ SetGlobal("bd_thrix_sacrifice_companion","global",1)
 ~ EXTERN xxBiffJ thrix_01
 
   IF ~RandomNum(4,1)~ THEN REPLY ~Biff is with me on a path of education. You will not get his soul.~ DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",2) IncrementGlobal("BD_NumInParty","bd4500",1)~ + 70
-  IF ~RandomNum(4,2)~ THEN REPLY ~Biff is with me on a path of education. You will not get his soul. You will not get his soul.~ DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",2) IncrementGlobal("BD_NumInParty","bd4500",1)~ + 71
-  IF ~RandomNum(4,3)~ THEN REPLY ~Biff is with me on a path of education. You will not get his soul. You will not get his soul.~ DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",2) IncrementGlobal("BD_NumInParty","bd4500",1)~ + 72
-  IF ~RandomNum(4,4)~ THEN REPLY ~Biff is with me on a path of education. You will not get his soul. You will not get his soul.~ DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",2) IncrementGlobal("BD_NumInParty","bd4500",1)~ + 73
+  IF ~RandomNum(4,2)~ THEN REPLY ~Biff is with me on a path of education. You will not get his soul.~ DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",2) IncrementGlobal("BD_NumInParty","bd4500",1)~ + 71
+  IF ~RandomNum(4,3)~ THEN REPLY ~Biff is with me on a path of education. You will not get his soul.~ DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",2) IncrementGlobal("BD_NumInParty","bd4500",1)~ + 72
+  IF ~RandomNum(4,4)~ THEN REPLY ~Biff is with me on a path of education. You will not get his soul.~ DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",2) IncrementGlobal("BD_NumInParty","bd4500",1)~ + 73
 
   IF ~!Global("BD_NumInParty","bd4500",1)
 !Global("BD_NumInParty","bd4500",2)
@@ -1282,23 +1304,217 @@ END
 /* I do the reaction in one CHAIN. Change this to whatever dialogue tree fits your NPC. */
 CHAIN
 IF ~OR(2)
-Global("xxBiff_SoDThrix","GLOBAL",6)
-Global("xxBiff_SoDThrix","GLOBAL",9)~ THEN xxBiffJ after_thrix
-~You were quite ready to give my soul to that fiend, &lt;CHARNAME&gt;.~ 
-DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",11)~
+	Global("xxBiff_SoDThrix","GLOBAL",6)
+	//  Global("xxBiff_SoDThrix","GLOBAL",7) //etc.: according to where your NPC should react and adjust the OR() accordingly
+	Global("xxBiff_SoDThrix","GLOBAL",9)~ THEN xxBiffJ after_thrix
+~You were quite ready to give my soul to that fiend, &lt;CHARNAME&gt;.~
 == xxBiffJ IF ~Global("BD_Thrix_riddle_won","GLOBAL",1)~ THEN ~Luckily, you won the game, so no harm done.~
 == xxBiffJ IF ~Global("xxBiff_SoDThrix","GLOBAL",6) !Global("BD_Thrix_riddle_won","GLOBAL",1)~ THEN ~I appreciate you tried to fight the fiend in the end, but unluckily, the harm was done.~
 == xxBiffJ IF ~Global("xxBiff_SoDThrix","GLOBAL",9) !Global("BD_Thrix_riddle_won","GLOBAL",1)~ THEN ~Why did you do that? Trading my soul to a fiend! You gave my soul a little bit too readily for my taste, you know.~
-EXIT
+END
+IF ~~ THEN DO ~SetGlobal("xxBiff_SoDThrix","GLOBAL",11)~ EXIT // We need to do this here or the checks above will not work.
+	</pre>
+		
+      <h2><a name="toc_22">25. Training the Recruits in the Coalition Camp</a></h2>
+	  <p>In the big coalition camp bd3000.are, there are six recruits where the PC and specific NPCs can help with their training: Clovis, Danine, Garrold, Hester, Morlis, and Taield. For most cases this is done by reply options with which the PC can ask NPCs for their help. The original reply options featuring this usually go along the lines of "npcname, do you have something to say?" with the exception of Morlis and Danine as described below.<br /> 
+	  Possibilities to contribute is depending on the NPC's class or race: </p>
+	  
+	  <ol>
+        <li>Clovis (bdclovis.dlg) can best be helped by one of the "small" races, as he is dwarf himself. He gets advice to go for the knees and joints instead of the (higher up) armored regions of his opponents.<br />
+		"Don't try to fight like a big one. Hitting up wears you out." (M'Khiin).<br />
+		"You want to stab at the enemy's torso. A natural instinct, I understand it—but it's not as effective as it could be, and I'm guessing it's hard on the arms, right?" (Glint).</li>
+        <li>Danine (bddanine.dlg) can best be helped by a thief. Her agility and showing her how to surprise her opponents (i.e. to fight "dirty") are her strengths. Safana will interject with her advice after the PC gave theirs. For compatibility reasons, I suggest to add reply options to ask an appropriate NPC for their advice directly. <br />
+		"If you don't mind, I think I can teach the private some tricks. You've got the right idea, but you're not taking it far enough." (Safana).<br />
+        <li>Garrold (bdgarrol.dlg) is best helped by a mage, by noticing that he better join the battle mages because he likes to learn and memorize patterns.<br />
+		"This young man seems more intelligent than most. Allow me to look at thine aura, soldier... I see much potential in thy abilities. Perhaps thou shouldst train with magic instead of steel." (Dynaheir).<br />
+		"It's obvious this weakling is no soldier. I've eaten chickens with thicker legs than his. He seems moderately intelligent, though. Get him into mage training. He may be of use some day." (Edwin).</li>
+        <li>A bard or cleric or a PC with WIS greater 10 can help Hester (bdhester.dlg). Hester is extremely anxious and needs help to overcome his fears. For some reason, some general advice à la "overcome your fear and you will feel better" is all he needs to hear, which is readily given even by Viconia if asked: "Everyone fears death, young one. It's the natural state of mortals. Shar teaches that it's foolish to chase hope or plan overmuch for the future. Death comes to all of us in the end. It's what we do in the moment that matters. - Life is loss. In the end, we lose our lives. Accept that truth and move forward." (Viconia).<br />
+		"Pain hurts, but it makes you stronger. Fear death and you'll never really live. - I just said that. You do it now." (M'Khiin).</li>
+        <li>Morlis (bdmorlis.dlg) can best be helped by a barbarian or blackguard. The trick is to realize that he has fun in killing and encourage him to do so. A (not evil aligned) barbarian can also notice his rage in battle and stress its positive purposes in war. This is the second recruit where the PC does not ask an NPC whether they have any advice / seem like they want to say something but where Dorn will interject after the PC's own advice. For compatibility reasons, I suggest to add reply options to ask an appropriate NPC for their advice directly.<br />
+		"I sense something in you, soldier. A darkness that reminds me of my own. You like killing, don't you?" (Dorn).</li>
+        <li>Taield (BDTAIELD.dlg) can best be helped by a fighter or a half-elf like him. For some reason his being half-elf makes him feel different to the normal recruits and somewhat alienated to the cause of the coalition. A half-elf NPC or NPCs with such experiences can address these feelings of lonlyness to help him identify with the group and the war in total. A fighter can just give him intensive sparring, which will also help.<br />
+		"I have never been a soldier, but I know what it is to be different. I was raised by druids, not by my parents, and often felt alone. - Everyone has a reason to feel alone. We each make our own paths and fight for our own causes. You must find the strength within to endure, as do we all." (Jaheira).</li>
+      </ol>
+	  <p>For simplification of the example, Biff will just give everyone good advice which I partly took from my NPC mods because I'm lazy. He's the Understudy, after all!</p> 
+		  <p>It is convenient to use the existent reply options for the 6 recruits. To account for EET compatibility we need to consider that all BG1+SoD string reference numbers in EET are higher by 200,000, meaning the sring reference #48085 in SoD will be #248085 in EET. Put this into the ALWAYS block of the tp2 so existing string reference numbers can be used for BG:SoD and EET in one go, by adding %2% in front of the string number.</p>
+		  <p class="info">Note: this works although the defined "2" is a string, not a number. There might be instances where this syntax will not work like it does here, e.g. for journal titles in ADD_JOURNAL in the tp2. Also, only adding a "2" only works for SoD strings that all have at least 5 digits. For smaller numbers from BG1 there would be additional zeros missing.</p>
+	 <pre class="code">  
+/* Define a variable to account for the differences in string ref numbers between BG:SoD and EET. - Works for string references in d- or baf-files. */
+  ACTION_IF GAME_IS ~bgee~ BEGIN
+    OUTER_SPRINT ~2~ ~~
+  END
+
+  ACTION_IF GAME_IS ~eet~ BEGIN
+    OUTER_SPRINT ~2~ ~2~
+  END
+	</pre>
+	  <p>This is what we will put into a d-file,n the tutorial mod package it is called <strong>sod_event_comments.d</strong>. For your own NPC mod just pick what you think would suit your NPC's character, experience, and prowess:</p>
+	 <pre class="code">  
+/* Training the Recruits in the Coalition Camp */
+
+/* Clovis */
+EXTEND_BOTTOM BDCLOVIS 3
++ ~IfValidForPartyDialogue("xxBiff")~ + ~[PC reply]Biff, any advice?~ */ EXTERN xxBiffJ teach_clovis
+END
+
+CHAIN
+IF ~~ THEN xxBiffJ teach_clovis
+~I see a mistake smaller men do when trained by taller ones. Fighting wears your arms out quite a bit, doesn't it?~
+== #%2%48085 /* ~I do tire pretty quickly during drills. I thought I just needed more training.~ */
+== xxBiffJ ~Focus on weak spots were you do not have to reach upwards. There are more than you might think. The foes will fear you for it - and you will wear out less quickly.~
+END
+IF ~~ THEN DO ~IncrementGlobal("BD_FIGHTERS_SKILL","BD3000",2)
+SetGlobal("bd_sdd301_clovista_skill","global",2)~ EXTERN BDCLOVIS 5
+
+/* Danine */
+EXTEND_BOTTOM BDDANINE 3
++ ~IfValidForPartyDialogue("xxBiff")~ + ~Biff, you think you can teach this recruit to improve her skills?~ EXTERN xxBiffsj teach_danine
+END
+
+/* there will be a short fighting scene, then Biff talks again */
+EXTEND_BOTTOM BDDANINE 4
+IF ~IfValidForPartyDialogue("xxBiff")~ THEN DO ~SetGlobal("BD_DANINE_INTRO","BD3000",2)
+SetGlobal("xxBiff_BD_DANINE","BD3000",1)
+PlaySound("ACT_07")
+ReallyForceSpellRES("BDDANIN2",Myself)
+JumpToPoint([108.656])
+FaceObject("BDCLOVIS")
+Wait(1)
+ReallyForceSpellRES("BDDANIN1",Myself)
+ApplyDamage("BDCLOVIS",1,1)
+SetSequence(SEQ_ATTACK)
+ActionOverride("BDCLOVIS",SetSequence(SEQ_DIE))
+Wait(1)
+ActionOverride("BDCLOVIS",SetSequence(SEQ_AWAKE))
+Wait(1)
+ActionOverride("xxBiff",StartDialogNoSet("bddanine"))
+~ EXIT
+END
+
+APPEND xxBiffJ
+IF ~~ THEN teach_danine
+SAY ~I do. Try to be at places the foe doesn't expect you to be, be it yourself - or just your knife.~
+  IF ~~ THEN EXTERN ~BDDANINE~ 4
+END
+
+/* final dialogue after Danine tried out the advice */
+IF WEIGHT #-1 
+~Global("xxBiff_BD_DANINE","BD3000",1)~ THEN teach_danine_01
+  SAY ~Yes, that's it.~
+  IF ~~ THEN DO ~IncrementGlobal("BD_FIGHTERS_SKILL","BD3000",2)
+SetGlobal("bd_sdd301_danine_skill","global",2)
+SetGlobal("xxBiff_BD_DANINE","BD3000",2)
+~ EXTERN ~BDDANINE~ 5
+END
+END //APPEND
+
+/* Garrold */
+EXTEND_BOTTOM BDGARROL 1
++ ~IfValidForPartyDialogue("xxBiff")~ + ~Biff, you seem like you want to say something?~ EXTERN xxBiffJ teach_garrold
+END
+
+CHAIN
+IF ~~ THEN xxBiffJ teach_garrold
+~You definitely have potential. More than with what you do here. Would the battle mages take on new recruits as well?~
+END
+IF ~~ THEN DO ~IncrementGlobal("BD_FIGHTERS_SKILL","BD3000",2)
+SetGlobal("bd_sdd301_garrold_skill","global",2)~ EXTERN BDGARROL 3
+
+
+/* Hester */
+/* Hester has two possible states for reply options */
+EXTEND_BOTTOM BDHESTER 6
++ ~IfValidForPartyDialogue("xxBiff")~ + ~Biff, you think you can teach this recruit to improve his skills?~ EXTERN xxBiffJ teach_hester
+END
+
+EXTEND_BOTTOM BDHESTER 7
++ ~IfValidForPartyDialogue("xxBiff")~ + ~Biff, you think you can teach this recruit to improve his skills?~ EXTERN xxBiffJ teach_hester
+END
+
+CHAIN
+IF ~~ THEN xxBiffJ teach_hester
+~You need to focus on *why* you are here. The only thing worth being afraid of is that your foe will overpower you - and not because of yourself, but because of your friends and the ones that depend on you!~
+== BDHESTER #%2%48006 /* ~So by trying to avoid battle and all that comes with it, I'm missing out on my life now...?~ */
+== xxBiffJ ~Exactly.~
+END
+IF ~~ THEN DO ~IncrementGlobal("BD_FIGHTERS_SKILL","BD3000",2)
+SetGlobal("bd_sdd301_hester_skill","global",2)
+~ EXTERN ~BDHESTER~ 10
+
+/* Morlis */
+/* #1 The first example is for the advice a fighter would give. If your NPC recognizes Morlis' joy in killing, the dialogue would go differently, see below. */
+//--> take out from here if you want to use option #2 instead
+EXTEND_BOTTOM BDMORLIS 4
++ ~IfValidForPartyDialogue("xxBiff")~ + ~Biff, can you give some advice as a fighter?~ EXTERN xxBiffJ teach_morlis
+END
+
+CHAIN
+IF ~~ THEN xxBiffJ teach_morlis
+~You are strong and do not shy away from being hit. You need to focus that strength on the foe. Try to be in the first row. It is where your skill will be useful the most, as you do not have to watch out not to hit allies.~
+END
+IF ~~ THEN DO ~IncrementGlobal("BD_FIGHTERS_SKILL","BD3000",2)
+SetGlobal("bd_sdd301_morlis_skill","global",2)~ EXTERN BDMORLIS 8
+// <-- take out until here if you want to use option #2
+
+/* #2 Morlis, possibility to interact for an evil NPC */
+/* - taken out - remove this line if you want tuse option #2
+EXTEND_BOTTOM BDMORLIS 4
++ ~IfValidForPartyDialogue("xxBiff")~ + ~Biff, you look like you want to say something?~ EXTERN xxBiffJ teach_morlis_evil
+END
+
+CHAIN
+IF ~~ THEN xxBiffJ teach_morlis_evil
+~(Imitating Dorn's voice) I sense something in you, soldier. A darkness that reminds me of my own. You like killing, don't you?~
+== #%2%47935 /* ~I... yes. I do enjoy it. I thought if I said so, though, they wouldn't let me in the militia.~ */
+== xxBiffJ ~Well, it seems we really need every man we get. Make sure you're in the front row, though.~
+END
+IF ~~ THEN DO ~IncrementGlobal("BD_FIGHTERS_SKILL","BD3000",2)
+SetGlobal("bd_sdd301_morlis_skill","global",2)~ EXTERN BDMORLIS 6
+*/ //remove this line if you want to use option #2
+
+/* Taield */
+EXTEND_BOTTOM BDTAIELD 1
++ ~IfValidForPartyDialogue("xxBiff")~ + ~Biff, can you give this private some advice?~ EXTERN xxBiffJ teach_taield
+END
+
+CHAIN
+IF ~~ THEN xxBiffJ teach_taield
+~You seem to feel not full part of the group. I can sympathize with that... I'm always only seen as the second choice myself.~
+== BDTAIELD #%2%48070 /* ~I admit I've felt somewhat alienated. It's hard to feel part of the team when I'm so obviously different.~ */
+== xxBiffJ ~(Imitating Jaheira's voice) Everyone has a reason to feel alone. We each make our own paths and fight for our own causes. You must find the strength within to endure, as do we all.~
+END
+IF ~~ THEN DO ~IncrementGlobal("BD_FIGHTERS_SKILL","BD3000",2)
+SetGlobal("bd_sdd301_taield_skill","global",2)~ EXTERN BDTAIELD 6
+
 	</pre>
 	
-
-	       <h2><a name="toc_12b">Make the Mod EET compatible</a></h2>
-      <p>The depth of what is required for your mod to be EET compatible depends strongly on what your mod will cover. If your NPC is also available in BG:EE, then the naming differences of most BG1 resources (those files that needed renaming because BGII has different files of the same name) require the use of OUTER_SPRINT variables as defined in the widely used cpmvars.tpas for e.g. area names, Imoen's script name, or some cre file names. The principle of this multi-platform coding is described in cmorgan's tutorial <a href="https://www.gibberlings3.net/forums/topic/10003-crossing-the-great-divide/?page=1">Crossing the Great Divide</a>. k4thos made a list about different naming conventions <a href="https://cdn.rawgit.com/K4thos/EET/master/EET/docs/BG1%20reference%20table.html">here</a>.</p>
-	  <p>If looking "only" at SoD, there is the huge advantage that most resources didn't need to be renamed as SoD already uses unique file names and almost all resources are the same for SoD(BG:EE) and SoD(EET). One exception is Imoen's death variable: it is "IMOEN" in SoD and "IMOEN2" in EET.</p> 
+			
+      <h2><a name="toc_23">26. The Chicken, the Well, and the Dog Easter Egg</a></h2>
+	  <p>In the northwest of the Boareskyr Bridge area there is an old well. The easter egg is that putting the dusty chicken from the crusader's camp into it will lead to a dog appearing and all group NPCs giving some comment.</p>
+	  <p>In the game, the dog barks after every two possible NPC interactions. If the NPCs are not present, it will bark anyway. To make sure it will not bark twice after the interjection we check for Jaheira or Khalid's presence as they would talk first after the interjection point: if they are not present the dog will not bark additionally but just give his normal line he would give anway.</p>	 
+	  <p>Lines used by the dog are: Arf!, Yip!, Woof woof!, and Ruff!. Feel free to use a different exclamation than the example to increase variety.</p>
+	  <p>This is what we will put into Biff's d-file. In the tutorial mod package it is called <strong>sod_event_comments.d</strong>:</p>
+	 <pre class="code">  
+/* The Chicken, the Well, and the Dog Easter Egg */
+I_C_T BDDOGW01 0 C#BE_BDDOGW01_0
+== xxBiffsj IF ~IfValidForPartyDialogue("xxBiff")~ THEN ~We washed the chicken in the well and the dog came to collect it. Never gets old!~
+== BDDOGW01 IF ~IfValidForPartyDialogue("xxBiff")
+OR(2) IsValidForPartyDialogue("KHALID")
+IsValidForPartyDialogue("JAHEIRA")~ THEN ~Woof!~
+END
+	</pre>
+	
+		
+      <h2><a name="toc_24">27. Providing the "Skipit" Functionality for Cutscenes</a></h2>
+	  <p>I made this an extra How-To and will only give a link here: <a href="https://www.gibberlings3.net/forums/forum/62-modding-how-tos-and-tutorials/">[How-To] Using EE's "Skipit" Functionality for Mod Cutscenes </a></p>
+	  
+	
+	       <h2><a name="toc_12b">28. Make the Mod EET compatible</a></h2>
+      <p>The depth of what is required for your mod to be EET compatible depends strongly on what your mod will cover. If your NPC is also available in BG:EE, then the naming differences of most BG1 resources (those files that needed renaming because BGII has different files of the same name) require the use of OUTER_SPRINT variables as defined in the widely used cpmvars.tpas for e.g. area names, Imoen's scriptname, or some cre file names. The principle of this multi-platform coding is described in cmorgan's tutorial <a href="https://www.gibberlings3.net/forums/topic/10003-crossing-the-great-divide/?page=1">Crossing the Great Divide</a>. k4thos made a list about different naming conventions <a href="https://cdn.rawgit.com/K4thos/EET/master/EET/docs/BG1%20reference%20table.html">here</a>.</p>
+	  <p>If looking "only" at SoD, there is the huge advantage that most resources didn't need to be renamed as SoD already uses unique file names and almost all resources are the same for SoD(BG:EE) and SoD(EET). One exception is Imoen's death variable: it is "IMOEN" in SoD and "IMOEN2" in EET. And of course using string reference numbers need to be toggled: the EET numbers are the BG:SoD ones plus 200,000. One example how to unify this is given <a href="#toc_22">in Chapter 25: Training the Recruits in the Coalition Camp</a>.</p> 
 	  <p>Then the only question is whether the NPC will be available in BGII, too (and whether you realize this by a continuous NPC that has the same script variable (death name) in BGII, also), or whether the NPC should not be available if the player continuous into BGII after finishing SoD in EET.</p>
 	  <p>EET offers a very comfortable function to provide your NPC mod with all needed script additions etc. for the transitions BG1 -&gt; SoD, SoD -&gt; SoA, and SoA -&gt; ToB. The function is called EET_NPC_TRANSITION and there is a very detailed description how to use it and what it does in the according <a href="https://cdn.rawgit.com/K4thos/EET/master/EET/docs/Modder's Notes.html">Modder Notes</a> (It is well possible the link will not work because of the apostroph in it. Here is the address for copy&paste: https://cdn.rawgit.com/K4thos/EET/master/EET/docs/Modder's Notes.html.)</p>
-	  <p>Biff is supposed to be a SoD NPC, so the mod would be category "1" (BG:EE/SoD NPC). The needed parameters for the function would be the following:</p>
+	  <p>Biff is supposed to be an SoD NPC, so the mod would be category "1" (BG:EE/SoD NPC). The needed parameters for the function would be the following. Put this late into the <strong>tp2-file</strong>, at least after your NPC's script file compilation:</p>
 	  <pre class="code">
 /* EET compatibility: Biff is an BG1 (SoD) NPC only. His name will be mentioned on EET's fate spirit in ToB, but he will not be summonable (like all NPCs that didn't join the group in BGII). */
 
@@ -1306,15 +1522,15 @@ ACTION_IF GAME_IS ~eet~ BEGIN
   INCLUDE ~EET/other/EET_functions.tph~ //this function will be in the player's own EET folder
   LAF ~EET_NPC_TRANSITION~ 
     INT_VAR
-      type = 1 //Biff is only available in BG:EE/SoD
+      type = 1 //Biff is only available in BG:EE/SoD. Adapt this if needed; including the additional STR_VARs
     STR_VAR
-      dv = "xxBiff" //Biff's script name (death variable)
+      dv = "xxBiff" //Biff's scriptname (death variable)
       override_BG1 = "" /* OVERRIDE script in BG:EE. Put your NPC's BG:EE script here UNLESS you use the same script for BG:EE and SoD 
 (adds a "destruct in Chapter greater than 7" scriptblock, for example if your NPC was spawned in BG:EE but was never in party (although "BeenInParty" is not being checked by this scriptblock)). 
 If your NPC is SoD only like Biff, leave this open. */
       override_SoD = "xxBiffs" //OVERRIDE script in SoD. This will add a "DestroySelf()" in Chapter greater than 13 to the SoD script.
-      traFile = "%MOD_FOLDER%/tra/%LANGUAGE%/dialog.tra" //path to the text line for the ToB Fate Spirit summoning
-      string = "@0" /* ~Bring me Biff the Understudy.~ */
+      traFile = "%MOD_FOLDER%/tra/%LANGUAGE%/GAME-XXBIFF.tra" //path to the text line for the ToB Fate Spirit summoning
+      string = "@0" /* ~Bring me Biff the Understudy.~ */ //from the above specified tra file
       stringPosDV = "Baeloth" //Name after which Biff's should be put into the order of reply options at the fate spirit summoning dialogue. 
 /* From the "Modder's Notes for Baldur's Gate: Enhanced Edition Trilogy (EET)":
       //Aerie, Ajantis, Alora, Anomen, Baeloth, Branwen, Cernd, Coran, Corwin, Dorn, Dynaheir, Edwin, Eldoth, Faldorn, Garrick,
@@ -1325,41 +1541,29 @@ If your NPC is SoD only like Biff, leave this open. */
 END	  
 	  </pre>
 	  <p>For Biff being an SoD mod only, this is basically it. The transition from SoD to SoA in EET is done by K#TELBGT.bcs which lets all NPCs that are not multiplayer characters leave the party. The EET_NPC_TRANSITION will add a DestroySelf() to Biff's OVERRIDE script if the chapter (of the continuous EET chapter system) hits chapter 14. So, we do not need to add anything to make sure he will not be present in BGII.</p> 
-				
-		
-      <h2><a name="toc_22">Placeholder</a></h2>
-	  <p>##</p>	  
-	  <p>This is what we will patch to <strong>##.bcs</strong>:</p>
-	 <pre class="code">  
-/* xx##.baf */
-/* Placeholder */
-
-	</pre>
-	  <p>And the tp2 patching:</p>
-	 <pre class="code">  
-/* Placeholder */
-EXTEND_BOTTOM ~##.bcs~ ~%MOD_FOLDER%/baf/xx##.baf~
-EVALUATE_BUFFER
-	</pre>
-	
-				
-		
-      <h2><a name="toc_23">Placeholder</a></h2>
-	  <p>##</p>	  
-	  <p>This is what we will patch to <strong>##.bcs</strong>:</p>
-	 <pre class="code">  
-/* xx##.baf */
-/* Placeholder */
-
-	</pre>
-	  <p>And the tp2 patching:</p>
-	 <pre class="code">  
-/* Placeholder */
-EXTEND_BOTTOM ~##.bcs~ ~%MOD_FOLDER%/baf/xx##.baf~
-EVALUATE_BUFFER
-	</pre>
 	  
-      <h2><a name="toc_100">Credits, Used Tools, and Helpful Links</a></h2>
+	  
+	  
+	  <h2><a name="toc_50">29. Promotion of the Road to Discovery Mod and its Possibilities for your NPC Mod</a></h2>	 
+	  <p><a href="https://www.gibberlings3.net/mods/other/road_to_discovery/">"Road to Discovery"</a> is a tweak mod for the SoD campaign (also with native EET compatibility). For players, it aims to make the coalition forces aware of Caelar's and Hephernaan's plans with focus on the actual important aim and danger of the crusade, and give reply options with which the PC can inform the coalition forces about what is going on. For this, all bits and pieces of information the PC can gather along the campaign are tracked and evaluated. Journal entries give an overview on what information the PC already gathered.</br>
+	  For modders, "Road to Discovery" introduces a variable-based tracking system about the different levels of knowledge the PC and the coalition officers gain throughout the campaign, which could be used for own mods, e.g. for fine tuning mod NPCs reactions to the depths of gained information about Caelar, Hephernaan, and the crusade, but also the Hooded Man's appearances.</p>
+	  <p>The mod is modular so every player as well as modder can chose how much changes and content they want to see/use. If only the second component of the mod is installed (the "main" component), only the variable tracking system will be installed - the player will see no difference while playing the game.</p>
+	  <p>For your own NPC mod, feel invited to use the tracking system of "Road to Discovery" to fine-tune your NPC's reactions to game events. I developped it for exactly that purpose - my own NPC mods - and a lot of effort was put into the tracking system and the different stages of tracked PC's knowledge.</p> 
+	  <p>The following lists the information from the SoD campaign "Road to Discovery" is considering. For detailed description of the used variables and the exact definition of the tracked infomation see inside the mod packge:</p>
+	  
+	  <ol>
+        <li>What is the main purpose of the crusade - what is Caelar proclaiming, and what is it really?</li>
+        <li>What truth lies in Caelar's proclamation - and her crusaders' belief - that Caelar protects the crusade with "divine powers of the pantheon"?</li>
+        <li>What is the background of Caelar's life and family, and how does it influence her motives?</li>
+        <li>Is Caelar a Bhaal Spawn?</li>
+        <li>Caelar is being betrayed? By who?</li>
+        <li>What are Hephernaan's plans?</li>
+        <li>The Hooded Man is stalking the PC, and why?</li>
+        <li>What does Caelar and Hephernaan want with the PC?</li>
+        <li>What was the attack in the palace with the weak poison for?</li>
+	  </ol>				
+	  
+      <h2><a name="toc_100">30. Credits, Used Tools, and Helpful Links</a></h2>
 	  <p>Thank you to Argent77 for the html template!</p>
 	  <p>Used Tools:</p>
       <p><a href="https://github.com/Argent77/NearInfinity/releases/latest">Near Infinity</a></p>
@@ -1372,9 +1576,24 @@ EVALUATE_BUFFER
       <p><a href="http://www.spellholdstudios.net/">Spellhold Studios</a></p>
       <p><a href="http://www.pocketplane.net/mambo/">Pocket PLane Group</a></p>
       <p><a href="http://forums.blackwyrmlair.net/index.php?showtopic=113">Prefix Reservation at Black Wyrm Lair Forums</a></p>
+	  <p><a href="https://www.gibberlings3.net/forums/topic/28835-toss-your-semi-useful-weidu-macros-here/page/9/#comment-297371">(and following posts) [How-To] "GET_RESPONSE_STRREFS function - finding the correct original game reply option number of a certain state number if knowing the stringref number of that reply option", by argent77</a></p>
+	  <p><a href="https://www.gibberlings3.net/forums/forum/62-modding-how-tos-and-tutorials/">[How-To] Using EE's "Skipit" Functionality for Mod Cutscenes </a></p>
+	  <p><a href="https://www.gibberlings3.net/forums/topic/10003-crossing-the-great-divide/?page=1">Tutorial: Crossing the Great Divide</a></p>
+	  <p><a href="https://cdn.rawgit.com/K4thos/EET/master/EET/docs/BG1%20reference%20table.html">BG1 Reference Table</a>.</p>
+	  <p><a href="https://cdn.rawgit.com/K4thos/EET/master/EET/docs/Modder's Notes.html">EET Modder Notes</a> (It is well possible the link will not work because of the apostroph in it. Here is the address for copy&paste: https://cdn.rawgit.com/K4thos/EET/master/EET/docs/Modder's Notes.html.)</p>
+	  <p><a href="https://www.gibberlings3.net/mods/other/road_to_discovery/">Mod: "Road to Discovery"</a></p>
 	  
 	  
-      <h2><a name="toc_101">Version History</a></h2>
+      <h2><a name="toc_101">31. Version History</a></h2>
+          <p>Version 3:</p>
+          <ul>
+            <li>New chapter: Training the Recruits in the Coalition Camp</li>
+            <li>New chapter: The Chicken, the Well, and the Dog Easter Egg</li>
+            <li>New chapter: Providing the "Skipit" Functionality for Cutscenes</li>
+            <li>New chapter: Promotion of the Road to Discovery Mod and its Possibilities for your NPC Mod</li>
+            <li>Chapter paragraphs are numbered now.</li>
+            <li>Chapters about commenting in final scene deprecated ("Last area bd6100.are: comment in abduction scene (EET)").</li>
+          </ul>	  
           <p>Version 2:</p>
           <ul>
             <li>~%MOD_FOLDER%/baf/xxbd4400_commenting.baf~ should be patched to bd4400.bcs via EXTEND_BOTTOM</li>

--- a/docs/Tutorial_SoDGeneralNPCThings.html
+++ b/docs/Tutorial_SoDGeneralNPCThings.html
@@ -492,6 +492,8 @@ THEN
 		SetGlobal("bd_mdd010z_ot","bd0101",0)
 		DisplayStringHead("xxBiff",~Wait... do I have all the scripts? (murmurs) Corwin, Dunkan, Glint... Yes, all here. (phew)~)
 		Continue()
+	RESPONSE #160
+		Continue()
 END
 	</pre>
      <p>And the according tp2 patching:</p>


### PR DESCRIPTION
Tutorial 1 updates to v8:
-     Tutorial was revised and updated with new content. This includes unification of used naming schemes, correction of typos and oversights. Proposed examples might have changed in details.
-     Rewritten first section for compatibility with EndlessBG1 mod. New title: General throughts to transition into SoD's "Korlasz' Crypt".
-     Chapter 2 "Add Biff to Corwin's list about companions in BG city" now uses I_C_T directly.
-     Content list order corrected.

Tutorial 2 updates to v7:
-     Tutorial was revised and updated with new content. This includes unification of used naming schemes, correction of typos and oversights. Proposed examples might have changed in details.
-     Chapter 3 "Biff visits the PC in Prison" expanded in case the NPC should visit as a love interest after Corwin.
-     Added Continue() to script additions via EXTEND_TOP except cutscenes.
-     Revised the order of actions in some script blocks.
-     Corrected typos and oversights.

Tutorial 3 updates to v3:- 
-     Tutorial was revised and updated with new content. This includes unification of used naming schemes, correction of typos and oversights. Proposed examples might have changed in details.
-     New chapter: Training the Recruits in the Coalition Camp
-     New chapter: The Chicken, the Well, and the Dog Easter Egg
-     New chapter: Providing the "Skipit" Functionality for Cutscenes
-     New chapter: Promotion of the Road to Discovery Mod and its Possibilities for your NPC Mod
-     Unified Biff's joined.dlg to "xxBiffJ".
-     Chapter paragraphs are numbered now.
-     Chapters about commenting in final scene deprecated ("Last area bd6100.are: comment in abduction scene (EET)").

Tutorial 4 updates to v3:
-     Tutorial was revised and updated with new content. This includes unification of used naming schemes, correction of typos and oversights. Proposed examples might have changed in details.
-     Added new chapter: Include Optional Component for Banters in "Dialog Style". Examples in chapters 1-3 adjusted for compatibility with new chapter 4. (i.e. used variables changed; comments on how to put all banters into one single baf file removed.)
-     Examples in chapters 1 and 3 expanded: Biff and Corwin banter two times now.